### PR TITLE
Unify services names

### DIFF
--- a/config/api_resources/order.yaml
+++ b/config/api_resources/order.yaml
@@ -8,11 +8,11 @@
             status: 200
             denormalization_context:
                 groups:
-                    - 'commerce_weavers_tpay:shop:order:pay'
+                    - 'commerce_weavers_sylius_tpay:shop:order:pay'
             normalization_context:
                 groups:
-                    - 'commerce_weavers_tpay:shop:order:pay_result'
+                    - 'commerce_weavers_sylius_tpay:shop:order:pay_result'
             validation_groups:
-                - 'commerce_weavers_tpay:shop:order:pay'
+                - 'commerce_weavers_sylius_tpay:shop:order:pay'
             openapi_context:
                 summary: 'Pay for the order'

--- a/config/config.php
+++ b/config/config.php
@@ -9,7 +9,7 @@ return static function(ContainerConfigurator $container): void {
 
     $parameters = $container->parameters();
 
-    $parameters->set('commerce_weavers_tpay.certificate.cache_ttl_in_seconds', 300);
-    $parameters->set('commerce_weavers_tpay.tpay_transaction_channels.cache_ttl_in_seconds', 300);
-    $parameters->set('commerce_weavers_tpay.waiting_for_payment.refresh_interval', 5);
+    $parameters->set('commerce_weavers_sylius_tpay.certificate.cache_ttl_in_seconds', 300);
+    $parameters->set('commerce_weavers_sylius_tpay.tpay_transaction_channels.cache_ttl_in_seconds', 300);
+    $parameters->set('commerce_weavers_sylius_tpay.waiting_for_payment.refresh_interval', 5);
 };

--- a/config/config/framework.php
+++ b/config/config/framework.php
@@ -7,7 +7,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Config\FrameworkConfig;
 
 return function(FrameworkConfig $framework): void {
-    $framework->assets()->package('commerce_weavers_tpay_shop', [
+    $framework->assets()->package('commerce_weavers_sylius_tpay_shop', [
         'json_manifest_path' => '%kernel.project_dir%/public/build/commerce-weavers/tpay/shop/manifest.json',
     ]);
 };

--- a/config/config/messenger.php
+++ b/config/config/messenger.php
@@ -7,14 +7,14 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use CommerceWeavers\SyliusTpayPlugin\Api\Command\PayByBlik;
 use Symfony\Config\FrameworkConfig;
 
-if (!defined('COMMERCE_WEAVERS_TPAY_SYNC_TRANSPORT')) {
-    define('COMMERCE_WEAVERS_TPAY_SYNC_TRANSPORT', 'commerce_weavers_tpay_sync');
+if (!defined('COMMERCE_WEAVERS_SYLIUS_TPAY_SYNC_TRANSPORT')) {
+    define('COMMERCE_WEAVERS_SYLIUS_TPAY_SYNC_TRANSPORT', 'commerce_weavers_sylius_tpay_sync');
 }
 
 return function(FrameworkConfig $framework): void {
     $messenger = $framework->messenger();
 
-    $messenger->transport(COMMERCE_WEAVERS_TPAY_SYNC_TRANSPORT)->dsn('sync://');
+    $messenger->transport(COMMERCE_WEAVERS_SYLIUS_TPAY_SYNC_TRANSPORT)->dsn('sync://');
 
-    $messenger->routing(PayByBlik::class)->senders([COMMERCE_WEAVERS_TPAY_SYNC_TRANSPORT]);
+    $messenger->routing(PayByBlik::class)->senders([COMMERCE_WEAVERS_SYLIUS_TPAY_SYNC_TRANSPORT]);
 };

--- a/config/config/sylius_template_events.php
+++ b/config/config/sylius_template_events.php
@@ -25,14 +25,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ],
             'sylius.shop.layout.javascripts' => [
                 'blocks' => [
-                    'commerce_weavers_tpay_scripts' => [
+                    'commerce_weavers_sylius_tpay_scripts' => [
                         'template' => '@CommerceWeaversSyliusTpayPlugin/shop/scripts.html.twig',
                     ],
                 ],
             ],
             'sylius.shop.layout.stylesheets' => [
                 'blocks' => [
-                    'commerce_weavers_tpay_styles' => [
+                    'commerce_weavers_sylius_tpay_styles' => [
                         'template' => '@CommerceWeaversSyliusTpayPlugin/shop/styles.html.twig',
                     ],
                 ],

--- a/config/config/webpack_encore.php
+++ b/config/config/webpack_encore.php
@@ -7,5 +7,5 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Config\WebpackEncoreConfig;
 
 return function(WebpackEncoreConfig $webpackEncore): void {
-    $webpackEncore->builds('commerce_weavers_tpay_shop', '%kernel.project_dir%/public/build/commerce-weavers/tpay/shop');
+    $webpackEncore->builds('commerce_weavers_sylius_tpay_shop', '%kernel.project_dir%/public/build/commerce-weavers/tpay/shop');
 };

--- a/config/config/winzou_state_machine.php
+++ b/config/config/winzou_state_machine.php
@@ -11,7 +11,7 @@ return function(ContainerConfigurator $container): void {
                 'before' => [
                     'tpay_refund_payment' => [
                         'on' => ['refund'],
-                        'do' => ['@commerce_weavers.tpay.refunding.dispatcher.refund', 'dispatch'],
+                        'do' => ['@commerce_weavers_sylius_tpay.refunding.dispatcher.refund', 'dispatch'],
                         'args' => ['object'],
                     ],
                 ],

--- a/config/serialization/Pay.xml
+++ b/config/serialization/Pay.xml
@@ -17,16 +17,16 @@
 >
     <class name="CommerceWeavers\SyliusTpayPlugin\Api\Command\Pay">
         <attribute name="successUrl">
-            <group>commerce_weavers_tpay:shop:order:pay</group>
+            <group>commerce_weavers_sylius_tpay:shop:order:pay</group>
         </attribute>
         <attribute name="failureUrl">
-            <group>commerce_weavers_tpay:shop:order:pay</group>
+            <group>commerce_weavers_sylius_tpay:shop:order:pay</group>
         </attribute>
         <attribute name="blikToken">
-            <group>commerce_weavers_tpay:shop:order:pay</group>
+            <group>commerce_weavers_sylius_tpay:shop:order:pay</group>
         </attribute>
         <attribute name="encodedCardData">
-            <group>commerce_weavers_tpay:shop:order:pay</group>
+            <group>commerce_weavers_sylius_tpay:shop:order:pay</group>
         </attribute>
     </class>
 </serializer>

--- a/config/serialization/PayResult.xml
+++ b/config/serialization/PayResult.xml
@@ -17,10 +17,10 @@
 >
     <class name="CommerceWeavers\SyliusTpayPlugin\Api\Command\PayResult">
         <attribute name="status">
-            <group>commerce_weavers_tpay:shop:order:pay_result</group>
+            <group>commerce_weavers_sylius_tpay:shop:order:pay_result</group>
         </attribute>
         <attribute name="transactionPaymentUrl">
-            <group>commerce_weavers_tpay:shop:order:pay_result</group>
+            <group>commerce_weavers_sylius_tpay:shop:order:pay_result</group>
         </attribute>
     </class>
 </serializer>

--- a/config/services.php
+++ b/config/services.php
@@ -13,8 +13,8 @@ return function(ContainerConfigurator $container): void {
         ->set('env(TPAY_CLIENT_SECRET)', '')
         ->set('env(TPAY_CARDS_API)', '')
         ->set('env(TPAY_NOTIFICATION_SECURITY_CODE)', '')
-        ->set('commerce_weavers_tpay.payum.create_transaction.success_route', 'sylius_shop_order_thank_you')
-        ->set('commerce_weavers_tpay.payum.create_transaction.error_route', 'sylius_shop_order_thank_you')
-        ->set('commerce_weavers_tpay.payum.create_transaction.notify_route', 'commerce_weavers_tpay_payment_notification')
+        ->set('commerce_weavers_sylius_tpay.payum.create_transaction.success_route', 'sylius_shop_order_thank_you')
+        ->set('commerce_weavers_sylius_tpay.payum.create_transaction.error_route', 'sylius_shop_order_thank_you')
+        ->set('commerce_weavers_sylius_tpay.payum.create_transaction.notify_route', 'commerce_weavers_sylius_tpay_payment_notification')
     ;
 };

--- a/config/services/api/command.php
+++ b/config/services/api/command.php
@@ -13,36 +13,36 @@ use CommerceWeavers\SyliusTpayPlugin\Api\Command\PayHandler;
 return function(ContainerConfigurator $container): void {
     $services = $container->services();
 
-    $services->set('commerce_weavers_tpay.api.command.pay_handler', PayHandler::class)
+    $services->set('commerce_weavers_sylius_tpay.api.command.pay_handler', PayHandler::class)
         ->args([
             service('sylius.repository.order'),
-            service('commerce_weavers_tpay.api.factory.next_command'),
+            service('commerce_weavers_sylius_tpay.api.factory.next_command'),
             service('sylius.command_bus'),
         ])
         ->tag('messenger.message_handler')
     ;
 
-    $services->set('commerce_weavers_tpay.api.command.abstract_pay_by_handler', AbstractPayByHandler::class)
+    $services->set('commerce_weavers_sylius_tpay.api.command.abstract_pay_by_handler', AbstractPayByHandler::class)
         ->abstract()
         ->args([
             service('sylius.repository.payment'),
             service('payum'),
-            service('commerce_weavers.tpay.payum.factory.create_transaction'),
+            service('commerce_weavers_sylius_tpay.payum.factory.create_transaction'),
         ])
     ;
 
-    $services->set('commerce_weavers_tpay.api.command.pay_by_blik_handler', PayByBlikHandler::class)
-        ->parent('commerce_weavers_tpay.api.command.abstract_pay_by_handler')
+    $services->set('commerce_weavers_sylius_tpay.api.command.pay_by_blik_handler', PayByBlikHandler::class)
+        ->parent('commerce_weavers_sylius_tpay.api.command.abstract_pay_by_handler')
         ->tag('messenger.message_handler')
     ;
 
-    $services->set('commerce_weavers_tpay.api.command.pay_by_card_handler', PayByCardHandler::class)
-        ->parent('commerce_weavers_tpay.api.command.abstract_pay_by_handler')
+    $services->set('commerce_weavers_sylius_tpay.api.command.pay_by_card_handler', PayByCardHandler::class)
+        ->parent('commerce_weavers_sylius_tpay.api.command.abstract_pay_by_handler')
         ->tag('messenger.message_handler')
     ;
 
-    $services->set('commerce_weavers_tpay.api.command.pay_by_redirect_handler', PayByRedirectHandler::class)
-        ->parent('commerce_weavers_tpay.api.command.abstract_pay_by_handler')
+    $services->set('commerce_weavers_sylius_tpay.api.command.pay_by_redirect_handler', PayByRedirectHandler::class)
+        ->parent('commerce_weavers_sylius_tpay.api.command.abstract_pay_by_handler')
         ->tag('messenger.message_handler')
     ;
 };

--- a/config/services/api/context_builder.php
+++ b/config/services/api/context_builder.php
@@ -10,11 +10,11 @@ use CommerceWeavers\SyliusTpayPlugin\Api\Serializer\ContextBuilder\OrderTokenAwa
 return function(ContainerConfigurator $container): void {
     $services = $container->services();
 
-    $services->set('commerce_weavers_tpay.api.serializer.context_builder.order_token_aware', OrderTokenAwareContextBuilder::class)
+    $services->set('commerce_weavers_sylius_tpay.api.serializer.context_builder.order_token_aware', OrderTokenAwareContextBuilder::class)
         ->decorate('api_platform.serializer.context_builder')
         ->args([
             service('.inner'),
         ])
-        ->alias(OrderTokenAwareContextBuilderInterface::class, 'commerce_weavers_tpay.api.serializer.context_builder.order_token_aware.inner')
+        ->alias(OrderTokenAwareContextBuilderInterface::class, 'commerce_weavers_sylius_tpay.api.serializer.context_builder.order_token_aware.inner')
     ;
 };

--- a/config/services/api/doctrine.php
+++ b/config/services/api/doctrine.php
@@ -11,7 +11,7 @@ use Sylius\Bundle\ApiBundle\Context\UserContextInterface;
 return function(ContainerConfigurator $container): void {
     $services = $container->services();
 
-    $services->set('commerce_weavers_tpay.api.doctrine.query_item_extension.order_shop_user', OrderShopUserItemExtension::class)
+    $services->set('commerce_weavers_sylius_tpay.api.doctrine.query_item_extension.order_shop_user', OrderShopUserItemExtension::class)
         ->decorate(\Sylius\Bundle\ApiBundle\Doctrine\QueryItemExtension\OrderShopUserItemExtension::class)
         ->args([
             service('.inner'),
@@ -19,7 +19,7 @@ return function(ContainerConfigurator $container): void {
         ])
     ;
 
-    $services->set('commerce_weavers_tpay.api.doctrine.query_item_extension.order_visitor', OrderVisitorItemExtension::class)
+    $services->set('commerce_weavers_sylius_tpay.api.doctrine.query_item_extension.order_visitor', OrderVisitorItemExtension::class)
         ->decorate(\Sylius\Bundle\ApiBundle\Doctrine\QueryItemExtension\OrderVisitorItemExtension::class)
         ->args([
             service('.inner'),

--- a/config/services/api/factory.php
+++ b/config/services/api/factory.php
@@ -13,25 +13,25 @@ use CommerceWeavers\SyliusTpayPlugin\Api\Factory\NextCommandFactoryInterface;
 return function(ContainerConfigurator $container): void {
     $services = $container->services();
 
-    $services->set('commerce_weavers_tpay.api.factory.next_command', NextCommandFactory::class)
+    $services->set('commerce_weavers_sylius_tpay.api.factory.next_command', NextCommandFactory::class)
         ->args([
-            tagged_iterator('commerce_weavers_tpay.api.factory.next_command'),
+            tagged_iterator('commerce_weavers_sylius_tpay.api.factory.next_command'),
         ])
-        ->alias(NextCommandFactoryInterface::class, 'commerce_weavers_tpay.api.factory.next_command')
+        ->alias(NextCommandFactoryInterface::class, 'commerce_weavers_sylius_tpay.api.factory.next_command')
     ;
 
-    $services->set('commerce_weavers_tpay.api.factory.next_command.pay_by_blik', PayByBlikFactory::class)
-        ->tag('commerce_weavers_tpay.api.factory.next_command')
+    $services->set('commerce_weavers_sylius_tpay.api.factory.next_command.pay_by_blik', PayByBlikFactory::class)
+        ->tag('commerce_weavers_sylius_tpay.api.factory.next_command')
     ;
 
-    $services->set('commerce_weavers_tpay.api.factory.next_command.pay_by_card', PayByCardFactory::class)
-        ->tag('commerce_weavers_tpay.api.factory.next_command')
+    $services->set('commerce_weavers_sylius_tpay.api.factory.next_command.pay_by_card', PayByCardFactory::class)
+        ->tag('commerce_weavers_sylius_tpay.api.factory.next_command')
     ;
 
-    $services->set('commerce_weavers_tpay.api.factory.next_command.pay_by_redirect', PayByRedirectFactory::class)
+    $services->set('commerce_weavers_sylius_tpay.api.factory.next_command.pay_by_redirect', PayByRedirectFactory::class)
         ->args([
             service('payum.dynamic_gateways.cypher'),
         ])
-        ->tag('commerce_weavers_tpay.api.factory.next_command')
+        ->tag('commerce_weavers_sylius_tpay.api.factory.next_command')
     ;
 };

--- a/config/services/api/validator.php
+++ b/config/services/api/validator.php
@@ -10,7 +10,7 @@ use CommerceWeavers\SyliusTpayPlugin\Api\Validator\Constraint\EncodedCardDataReq
 return function(ContainerConfigurator $container): void {
     $services = $container->services();
 
-    $services->set('commerce_weavers_tpay.api.validator.constraint.blik_token_required_validator', BlikTokenRequiredValidator::class)
+    $services->set('commerce_weavers_sylius_tpay.api.validator.constraint.blik_token_required_validator', BlikTokenRequiredValidator::class)
         ->args([
             service('sylius.repository.order'),
             service('payum.dynamic_gateways.cypher'),
@@ -18,7 +18,7 @@ return function(ContainerConfigurator $container): void {
         ->tag('validator.constraint_validator')
     ;
 
-    $services->set('commerce_weavers_tpay.api.validator.constraint.encoded_card_data_required_validator', EncodedCardDataRequiredValidator::class)
+    $services->set('commerce_weavers_sylius_tpay.api.validator.constraint.encoded_card_data_required_validator', EncodedCardDataRequiredValidator::class)
         ->args([
             service('sylius.repository.order'),
             service('payum.dynamic_gateways.cypher'),

--- a/config/services/context_provider.php
+++ b/config/services/context_provider.php
@@ -11,7 +11,7 @@ return static function(ContainerConfigurator $container): void {
 
     $services->set(BankListContextProvider::class)
         ->args([
-            service('commerce_weavers_tpay.tpay.provider.tpay_api_bank_list'),
+            service('commerce_weavers_sylius_tpay.tpay.provider.tpay_api_bank_list'),
         ])
         ->tag('sylius.ui.template_event.context_provider')
     ;

--- a/config/services/controller.php
+++ b/config/services/controller.php
@@ -16,7 +16,7 @@ return function(ContainerConfigurator $container): void {
             service('router'),
             service('sylius.factory.payum_resolve_next_route'),
             service('twig'),
-            param('commerce_weavers_tpay.waiting_for_payment.refresh_interval'),
+            param('commerce_weavers_sylius_tpay.waiting_for_payment.refresh_interval'),
         ])
         ->tag('controller.service_arguments')
     ;
@@ -24,8 +24,8 @@ return function(ContainerConfigurator $container): void {
     $services->set(PaymentNotificationAction::class)
         ->args([
             service('payum'),
-            service('commerce_weavers.tpay.payum.factory.notify'),
-            service('commerce_weavers_tpay.payum.factory.notify_data'),
+            service('commerce_weavers_sylius_tpay.payum.factory.notify'),
+            service('commerce_weavers_sylius_tpay.payum.factory.notify_data'),
         ])
         ->tag('controller.service_arguments')
     ;

--- a/config/services/fixtures.php
+++ b/config/services/fixtures.php
@@ -9,7 +9,7 @@ use CommerceWeavers\SyliusTpayPlugin\Fixture\Factory\PaymentMethodExampleFactory
 return function(ContainerConfigurator $container): void {
     $services = $container->services();
 
-    $services->set('commerce_weavers_tpay.fixture.factory.payment_method_example', PaymentMethodExampleFactory::class)
+    $services->set('commerce_weavers_sylius_tpay.fixture.factory.payment_method_example', PaymentMethodExampleFactory::class)
         ->decorate('sylius.fixture.example_factory.payment_method')
         ->args([
             service('.inner'),

--- a/config/services/form.php
+++ b/config/services/form.php
@@ -24,9 +24,9 @@ return function(ContainerConfigurator $container): void {
 
     $services->set(TpayGatewayConfigurationType::class)
         ->args([
-            service('commerce_weavers_tpay.form.event_listener.decrypt_gateway_config'),
-            service('commerce_weavers_tpay.form.event_listener.encrypt_gateway_config'),
-            service('commerce_weavers_tpay.form.event_listener.prevent_saving_empty_password_fields'),
+            service('commerce_weavers_sylius_tpay.form.event_listener.decrypt_gateway_config'),
+            service('commerce_weavers_sylius_tpay.form.event_listener.encrypt_gateway_config'),
+            service('commerce_weavers_sylius_tpay.form.event_listener.prevent_saving_empty_password_fields'),
         ])
         ->tag(
             'sylius.gateway_configuration_type',
@@ -37,35 +37,35 @@ return function(ContainerConfigurator $container): void {
 
     $services->set(TpayCardType::class)
         ->args([
-            service('commerce_weavers_tpay.form.data_transformer.card_type'),
+            service('commerce_weavers_sylius_tpay.form.data_transformer.card_type'),
         ])
         ->tag('form.type')
     ;
 
     $services->set(TpayPaymentDetailsType::class)
         ->args([
-            service('commerce_weavers_tpay.form.event_listener.remove_unnecessary_payment_details_fields'),
+            service('commerce_weavers_sylius_tpay.form.event_listener.remove_unnecessary_payment_details_fields'),
         ])
         ->tag('form.type')
     ;
 
-    $services->set('commerce_weavers_tpay.form.data_transformer.card_type', CardTypeDataTransformer::class);
+    $services->set('commerce_weavers_sylius_tpay.form.data_transformer.card_type', CardTypeDataTransformer::class);
 
     $services
-        ->set('commerce_weavers_tpay.form.event_listener.decrypt_gateway_config', DecryptGatewayConfigListener::class)
+        ->set('commerce_weavers_sylius_tpay.form.event_listener.decrypt_gateway_config', DecryptGatewayConfigListener::class)
         ->args([
             service('payum.dynamic_gateways.cypher'),
         ])
     ;
 
     $services
-        ->set('commerce_weavers_tpay.form.event_listener.encrypt_gateway_config', EncryptGatewayConfigListener::class)
+        ->set('commerce_weavers_sylius_tpay.form.event_listener.encrypt_gateway_config', EncryptGatewayConfigListener::class)
         ->args([
             service('payum.dynamic_gateways.cypher'),
         ])
     ;
 
-    $services->set('commerce_weavers_tpay.form.event_listener.prevent_saving_empty_password_fields', PreventSavingEmptyPasswordFieldsListener::class);
+    $services->set('commerce_weavers_sylius_tpay.form.event_listener.prevent_saving_empty_password_fields', PreventSavingEmptyPasswordFieldsListener::class);
 
-    $services->set('commerce_weavers_tpay.form.event_listener.remove_unnecessary_payment_details_fields', RemoveUnnecessaryPaymentDetailsFieldsListener::class);
+    $services->set('commerce_weavers_sylius_tpay.form.event_listener.remove_unnecessary_payment_details_fields', RemoveUnnecessaryPaymentDetailsFieldsListener::class);
 };

--- a/config/services/payum/action.php
+++ b/config/services/payum/action.php
@@ -25,40 +25,40 @@ return function(ContainerConfigurator $container): void {
 
     $services->set(CaptureAction::class)
         ->args([
-            service('commerce_weavers.tpay.payum.factory.create_transaction'),
+            service('commerce_weavers_sylius_tpay.payum.factory.create_transaction'),
         ])
         ->tag('payum.action', ['factory' => TpayGatewayFactory::NAME, 'alias' => 'cw.tpay.capture'])
     ;
 
     $services->set(CreateCardTransactionAction::class)
         ->args([
-            service('commerce_weavers_tpay.tpay.factory.create_card_payment_payload'),
-            service('commerce_weavers_tpay.payum.factory.token.notify'),
+            service('commerce_weavers_sylius_tpay.tpay.factory.create_card_payment_payload'),
+            service('commerce_weavers_sylius_tpay.payum.factory.token.notify'),
         ])
         ->tag('payum.action', ['factory' => TpayGatewayFactory::NAME, 'alias' => 'cw.tpay.create_card_transaction'])
     ;
 
     $services->set(CreateBlikLevelZeroTransactionAction::class)
         ->args([
-            service('commerce_weavers_tpay.tpay.factory.create_blik_level_zero_payment_payload'),
-            service('commerce_weavers_tpay.payum.factory.token.notify'),
+            service('commerce_weavers_sylius_tpay.tpay.factory.create_blik_level_zero_payment_payload'),
+            service('commerce_weavers_sylius_tpay.payum.factory.token.notify'),
         ])
         ->tag('payum.action', ['factory' => TpayGatewayFactory::NAME, 'alias' => 'cw.tpay.create_blik_level_zero_transaction'])
     ;
 
     $services->set(CreateRedirectBasedTransactionAction::class)
         ->args([
-            service('commerce_weavers_tpay.tpay.factory.create_redirect_based_payment_payload'),
-            service('commerce_weavers_tpay.payum.factory.token.notify'),
+            service('commerce_weavers_sylius_tpay.tpay.factory.create_redirect_based_payment_payload'),
+            service('commerce_weavers_sylius_tpay.payum.factory.token.notify'),
         ])
         ->tag('payum.action', ['factory' => TpayGatewayFactory::NAME, 'alias' => 'cw.tpay.create_redirect_based_transaction'])
     ;
 
     $services->set(NotifyAction::class)
         ->args([
-            service('commerce_weavers_tpay.tpay.security.notification.factory.basic_payment'),
-            service('commerce_weavers_tpay.tpay.security.notification.verifier.checksum'),
-            service('commerce_weavers_tpay.tpay.security.notification.verifier.signature'),
+            service('commerce_weavers_sylius_tpay.tpay.security.notification.factory.basic_payment'),
+            service('commerce_weavers_sylius_tpay.tpay.security.notification.verifier.checksum'),
+            service('commerce_weavers_sylius_tpay.tpay.security.notification.verifier.signature'),
         ])
         ->tag('payum.action', ['factory' => TpayGatewayFactory::NAME, 'alias' => 'cw.tpay.notify'])
     ;
@@ -81,8 +81,8 @@ return function(ContainerConfigurator $container): void {
 
     $services->set(CreatePayByLinkTransactionAction::class)
         ->args([
-            service('commerce_weavers_tpay.tpay.factory.create_pay_by_link_payment_payload'),
-            service('commerce_weavers_tpay.payum.factory.token.notify'),
+            service('commerce_weavers_sylius_tpay.tpay.factory.create_pay_by_link_payment_payload'),
+            service('commerce_weavers_sylius_tpay.payum.factory.token.notify'),
         ])
         ->tag('payum.action', ['factory' => TpayGatewayFactory::NAME, 'alias' => 'cw.tpay.create_pay_by_link_transaction'])
     ;

--- a/config/services/payum/factory.php
+++ b/config/services/payum/factory.php
@@ -25,24 +25,24 @@ return function(ContainerConfigurator $container): void {
         ->tag('payum.gateway_factory_builder', ['factory' => TpayGatewayFactory::NAME])
     ;
 
-    $services->set('commerce_weavers.tpay.payum.factory.notify', NotifyFactory::class)
-        ->alias(NotifyFactoryInterface::class, 'commerce_weavers.tpay.payum.factory.notify')
+    $services->set('commerce_weavers_sylius_tpay.payum.factory.notify', NotifyFactory::class)
+        ->alias(NotifyFactoryInterface::class, 'commerce_weavers_sylius_tpay.payum.factory.notify')
     ;
 
-    $services->set('commerce_weavers.tpay.payum.factory.create_transaction', CreateTransactionFactory::class)
-        ->alias(CreateTransactionFactoryInterface::class, 'commerce_weavers.tpay.payum.factory.create_transaction')
+    $services->set('commerce_weavers_sylius_tpay.payum.factory.create_transaction', CreateTransactionFactory::class)
+        ->alias(CreateTransactionFactoryInterface::class, 'commerce_weavers_sylius_tpay.payum.factory.create_transaction')
     ;
 
-    $services->set('commerce_weavers_tpay.payum.factory.notify_data', NotifyDataFactory::class)
-        ->alias(NotifyDataFactoryInterface::class, 'commerce_weavers_tpay.payum.factory.notify_data')
+    $services->set('commerce_weavers_sylius_tpay.payum.factory.notify_data', NotifyDataFactory::class)
+        ->alias(NotifyDataFactoryInterface::class, 'commerce_weavers_sylius_tpay.payum.factory.notify_data')
     ;
 
-    $services->set('commerce_weavers_tpay.payum.factory.token.notify', NotifyTokenFactory::class)
+    $services->set('commerce_weavers_sylius_tpay.payum.factory.token.notify', NotifyTokenFactory::class)
         ->args([
             service('payum'),
             service('router'),
-            param('commerce_weavers_tpay.payum.create_transaction.notify_route'),
+            param('commerce_weavers_sylius_tpay.payum.create_transaction.notify_route'),
         ])
-        ->alias(NotifyTokenFactoryInterface::class, 'commerce_weavers_tpay.payum.factory.token.notify')
+        ->alias(NotifyTokenFactoryInterface::class, 'commerce_weavers_sylius_tpay.payum.factory.token.notify')
     ;
 };

--- a/config/services/refunding.php
+++ b/config/services/refunding.php
@@ -12,18 +12,18 @@ use Sylius\Bundle\CoreBundle\SyliusCoreBundle;
 return function(ContainerConfigurator $container): void {
     $services = $container->services();
 
-    $services->set('commerce_weavers.tpay.refunding.dispatcher.refund', RefundDispatcher::class)
+    $services->set('commerce_weavers_sylius_tpay.refunding.dispatcher.refund', RefundDispatcher::class)
         ->public()
         ->args([
             service('payum'),
         ])
-        ->alias(RefundDispatcherInterface::class, 'commerce_weavers.tpay.refunding.dispatcher.refund')
+        ->alias(RefundDispatcherInterface::class, 'commerce_weavers_sylius_tpay.refunding.dispatcher.refund')
     ;
 
     if (SyliusCoreBundle::VERSION_ID >= 11300) {
-        $services->set('commerce_weavers.tpay.refunding.workflow.listener.dispatch_refund', DispatchRefundListener::class)
+        $services->set('commerce_weavers_sylius_tpay.refunding.workflow.listener.dispatch_refund', DispatchRefundListener::class)
             ->args([
-                service('commerce_weavers.tpay.refunding.dispatcher.refund'),
+                service('commerce_weavers_sylius_tpay.refunding.dispatcher.refund'),
             ])
             ->tag('kernel.event_listener', ['event' => 'workflow.sylius_payment.transition.refund'])
         ;

--- a/config/services/tpay.php
+++ b/config/services/tpay.php
@@ -33,103 +33,103 @@ use CommerceWeavers\SyliusTpayPlugin\Tpay\Provider\TpayApiBankListProviderInterf
 return static function(ContainerConfigurator $container): void {
     $services = $container->services();
 
-    $services->set('commerce_weavers_tpay.tpay.factory.create_blik_level_zero_payment_payload', CreateBlikLevelZeroPaymentPayloadFactory::class)
+    $services->set('commerce_weavers_sylius_tpay.tpay.factory.create_blik_level_zero_payment_payload', CreateBlikLevelZeroPaymentPayloadFactory::class)
         ->args([
-            service('commerce_weavers_tpay.tpay.factory.create_redirect_based_payment_payload'),
+            service('commerce_weavers_sylius_tpay.tpay.factory.create_redirect_based_payment_payload'),
         ])
-        ->alias(CreateBlikLevelZeroPaymentPayloadFactoryInterface::class, 'commerce_weavers_tpay.factory.create_blik_level_zero_payment_payload')
+        ->alias(CreateBlikLevelZeroPaymentPayloadFactoryInterface::class, 'commerce_weavers_sylius_tpay.factory.create_blik_level_zero_payment_payload')
     ;
 
-    $services->set('commerce_weavers_tpay.tpay.factory.create_card_payment_payload', CreateCardPaymentPayloadFactory::class)
+    $services->set('commerce_weavers_sylius_tpay.tpay.factory.create_card_payment_payload', CreateCardPaymentPayloadFactory::class)
         ->args([
-            service('commerce_weavers_tpay.tpay.factory.create_redirect_based_payment_payload'),
+            service('commerce_weavers_sylius_tpay.tpay.factory.create_redirect_based_payment_payload'),
         ])
-        ->alias(CreateCardPaymentPayloadFactoryInterface::class, 'commerce_weavers_tpay.factory.create_card_payment_payload')
+        ->alias(CreateCardPaymentPayloadFactoryInterface::class, 'commerce_weavers_sylius_tpay.factory.create_card_payment_payload')
     ;
 
-    $services->set('commerce_weavers_tpay.tpay.factory.create_redirect_based_payment_payload', CreateRedirectBasedPaymentPayloadFactory::class)
+    $services->set('commerce_weavers_sylius_tpay.tpay.factory.create_redirect_based_payment_payload', CreateRedirectBasedPaymentPayloadFactory::class)
         ->args([
             service('router'),
-            param('commerce_weavers_tpay.payum.create_transaction.success_route'),
-            param('commerce_weavers_tpay.payum.create_transaction.error_route'),
+            param('commerce_weavers_sylius_tpay.payum.create_transaction.success_route'),
+            param('commerce_weavers_sylius_tpay.payum.create_transaction.error_route'),
         ])
-        ->alias(CreateRedirectBasedPaymentPayloadFactoryInterface::class, 'commerce_weavers_tpay.factory.create_redirect_based_payment_payload')
+        ->alias(CreateRedirectBasedPaymentPayloadFactoryInterface::class, 'commerce_weavers_sylius_tpay.factory.create_redirect_based_payment_payload')
     ;
 
-    $services->set('commerce_weavers_tpay.tpay.factory.create_pay_by_link_payment_payload', CreatePayByLinkPayloadFactory::class)
+    $services->set('commerce_weavers_sylius_tpay.tpay.factory.create_pay_by_link_payment_payload', CreatePayByLinkPayloadFactory::class)
         ->args([
-            service('commerce_weavers_tpay.tpay.factory.create_redirect_based_payment_payload'),
+            service('commerce_weavers_sylius_tpay.tpay.factory.create_redirect_based_payment_payload'),
         ])
-        ->alias(CreatePayByLinkPayloadFactoryInterface::class, 'commerce_weavers_tpay.factory.create_pay_by_link_payment_payload')
+        ->alias(CreatePayByLinkPayloadFactoryInterface::class, 'commerce_weavers_sylius_tpay.factory.create_pay_by_link_payment_payload')
     ;
 
-    $services->set('commerce_weavers_tpay.tpay.security.notification.factory.basic_payment', BasicPaymentFactory::class)
-        ->alias(BasicPaymentFactory::class, 'commerce_weavers_tpay.security.notification.factory.basic_payment')
+    $services->set('commerce_weavers_sylius_tpay.tpay.security.notification.factory.basic_payment', BasicPaymentFactory::class)
+        ->alias(BasicPaymentFactory::class, 'commerce_weavers_sylius_tpay.security.notification.factory.basic_payment')
     ;
 
-    $services->set('commerce_weavers_tpay.tpay.security.notification.factory.x509', X509Factory::class)
-        ->alias(X509FactoryInterface::class, 'commerce_weavers_tpay.security.notification.factory.x509')
+    $services->set('commerce_weavers_sylius_tpay.tpay.security.notification.factory.x509', X509Factory::class)
+        ->alias(X509FactoryInterface::class, 'commerce_weavers_sylius_tpay.security.notification.factory.x509')
     ;
 
-    $services->set('commerce_weavers_tpay.tpay.security.notification.resolver.certificate', CertificateResolver::class)
-        ->alias(CertificateResolverInterface::class, 'commerce_weavers_tpay.security.notification.resolver.certificate')
+    $services->set('commerce_weavers_sylius_tpay.tpay.security.notification.resolver.certificate', CertificateResolver::class)
+        ->alias(CertificateResolverInterface::class, 'commerce_weavers_sylius_tpay.security.notification.resolver.certificate')
     ;
 
-    $services->set('commerce_weavers_tpay.tpay.security.notification.resolver.cached_certificate', CachedCertificateResolver::class)
-        ->decorate('commerce_weavers_tpay.tpay.security.notification.resolver.certificate')
-        ->args([
-            service('cache.app'),
-            service('.inner'),
-            param('commerce_weavers_tpay.certificate.cache_ttl_in_seconds'),
-        ])
-    ;
-
-    $services->set('commerce_weavers_tpay.tpay.security.notification.resolver.trusted_certificate', TrustedCertificateResolver::class)
-        ->alias(TrustedCertificateResolverInterface::class, 'commerce_weavers_tpay.security.notification.resolver.trusted_certificate')
-    ;
-
-    $services->set('commerce_weavers_tpay.tpay.security.notification.resolver.cached_trusted_certificate', CachedTrustedCertificateResolver::class)
-        ->decorate('commerce_weavers_tpay.tpay.security.notification.resolver.trusted_certificate')
+    $services->set('commerce_weavers_sylius_tpay.tpay.security.notification.resolver.cached_certificate', CachedCertificateResolver::class)
+        ->decorate('commerce_weavers_sylius_tpay.tpay.security.notification.resolver.certificate')
         ->args([
             service('cache.app'),
             service('.inner'),
-            param('commerce_weavers_tpay.certificate.cache_ttl_in_seconds'),
+            param('commerce_weavers_sylius_tpay.certificate.cache_ttl_in_seconds'),
         ])
     ;
 
-    $services->set('commerce_weavers_tpay.tpay.security.notification.verifier.checksum', ChecksumVerifier::class)
-        ->alias(ChecksumVerifierInterface::class, 'commerce_weavers_tpay.security.notification.verifier.checksum')
+    $services->set('commerce_weavers_sylius_tpay.tpay.security.notification.resolver.trusted_certificate', TrustedCertificateResolver::class)
+        ->alias(TrustedCertificateResolverInterface::class, 'commerce_weavers_sylius_tpay.security.notification.resolver.trusted_certificate')
     ;
 
-    $services->set('commerce_weavers_tpay.tpay.security.notification.verifier.signature', SignatureVerifier::class)
+    $services->set('commerce_weavers_sylius_tpay.tpay.security.notification.resolver.cached_trusted_certificate', CachedTrustedCertificateResolver::class)
+        ->decorate('commerce_weavers_sylius_tpay.tpay.security.notification.resolver.trusted_certificate')
         ->args([
-            service('commerce_weavers_tpay.tpay.security.notification.resolver.certificate'),
-            service('commerce_weavers_tpay.tpay.security.notification.resolver.trusted_certificate'),
-            service('commerce_weavers_tpay.tpay.security.notification.factory.x509'),
+            service('cache.app'),
+            service('.inner'),
+            param('commerce_weavers_sylius_tpay.certificate.cache_ttl_in_seconds'),
         ])
-        ->alias(SignatureVerifierInterface::class, 'commerce_weavers_tpay.security.notification.verifier.signature')
     ;
 
-    $services->set('commerce_weavers_tpay.tpay.provider.tpay_api_bank_list', TpayApiBankListProvider::class)
+    $services->set('commerce_weavers_sylius_tpay.tpay.security.notification.verifier.checksum', ChecksumVerifier::class)
+        ->alias(ChecksumVerifierInterface::class, 'commerce_weavers_sylius_tpay.security.notification.verifier.checksum')
+    ;
+
+    $services->set('commerce_weavers_sylius_tpay.tpay.security.notification.verifier.signature', SignatureVerifier::class)
         ->args([
-            service('commerce_weavers_tpay.tpay.resolver.tpay_transaction_channel_resolver'),
+            service('commerce_weavers_sylius_tpay.tpay.security.notification.resolver.certificate'),
+            service('commerce_weavers_sylius_tpay.tpay.security.notification.resolver.trusted_certificate'),
+            service('commerce_weavers_sylius_tpay.tpay.security.notification.factory.x509'),
         ])
-        ->alias(TpayApiBankListProviderInterface::class, 'commerce_weavers_tpay.provider.tpay_api_bank_list')
+        ->alias(SignatureVerifierInterface::class, 'commerce_weavers_sylius_tpay.security.notification.verifier.signature')
     ;
 
-    $services->set('commerce_weavers_tpay.tpay.resolver.tpay_transaction_channel_resolver', TpayTransactionChannelResolver::class)
+    $services->set('commerce_weavers_sylius_tpay.tpay.provider.tpay_api_bank_list', TpayApiBankListProvider::class)
+        ->args([
+            service('commerce_weavers_sylius_tpay.tpay.resolver.tpay_transaction_channel_resolver'),
+        ])
+        ->alias(TpayApiBankListProviderInterface::class, 'commerce_weavers_sylius_tpay.provider.tpay_api_bank_list')
+    ;
+
+    $services->set('commerce_weavers_sylius_tpay.tpay.resolver.tpay_transaction_channel_resolver', TpayTransactionChannelResolver::class)
         ->args([
             service('payum'),
         ])
-        ->alias(TpayApiBankListProviderInterface::class, 'commerce_weavers_tpay.resolver.tpay_transaction_channel_resolver')
+        ->alias(TpayApiBankListProviderInterface::class, 'commerce_weavers_sylius_tpay.resolver.tpay_transaction_channel_resolver')
     ;
 
-    $services->set('commerce_weavers_tpay.tpay.resolver.cached_tpay_transaction_channel_resolver', CachedTpayTransactionChannelResolver::class)
-        ->decorate('commerce_weavers_tpay.tpay.resolver.tpay_transaction_channel_resolver')
+    $services->set('commerce_weavers_sylius_tpay.tpay.resolver.cached_tpay_transaction_channel_resolver', CachedTpayTransactionChannelResolver::class)
+        ->decorate('commerce_weavers_sylius_tpay.tpay.resolver.tpay_transaction_channel_resolver')
         ->args([
             service('.inner'),
             service('cache.app'),
-            param('commerce_weavers_tpay.tpay_transaction_channels.cache_ttl_in_seconds'),
+            param('commerce_weavers_sylius_tpay.tpay_transaction_channels.cache_ttl_in_seconds'),
         ])
     ;
 };

--- a/config/services/tpay.php
+++ b/config/services/tpay.php
@@ -37,14 +37,14 @@ return static function(ContainerConfigurator $container): void {
         ->args([
             service('commerce_weavers_sylius_tpay.tpay.factory.create_redirect_based_payment_payload'),
         ])
-        ->alias(CreateBlikLevelZeroPaymentPayloadFactoryInterface::class, 'commerce_weavers_sylius_tpay.factory.create_blik_level_zero_payment_payload')
+        ->alias(CreateBlikLevelZeroPaymentPayloadFactoryInterface::class, 'commerce_weavers_sylius_tpay.tpay.factory.create_blik_level_zero_payment_payload')
     ;
 
     $services->set('commerce_weavers_sylius_tpay.tpay.factory.create_card_payment_payload', CreateCardPaymentPayloadFactory::class)
         ->args([
             service('commerce_weavers_sylius_tpay.tpay.factory.create_redirect_based_payment_payload'),
         ])
-        ->alias(CreateCardPaymentPayloadFactoryInterface::class, 'commerce_weavers_sylius_tpay.factory.create_card_payment_payload')
+        ->alias(CreateCardPaymentPayloadFactoryInterface::class, 'commerce_weavers_sylius_tpay.tpay.factory.create_card_payment_payload')
     ;
 
     $services->set('commerce_weavers_sylius_tpay.tpay.factory.create_redirect_based_payment_payload', CreateRedirectBasedPaymentPayloadFactory::class)
@@ -53,26 +53,26 @@ return static function(ContainerConfigurator $container): void {
             param('commerce_weavers_sylius_tpay.payum.create_transaction.success_route'),
             param('commerce_weavers_sylius_tpay.payum.create_transaction.error_route'),
         ])
-        ->alias(CreateRedirectBasedPaymentPayloadFactoryInterface::class, 'commerce_weavers_sylius_tpay.factory.create_redirect_based_payment_payload')
+        ->alias(CreateRedirectBasedPaymentPayloadFactoryInterface::class, 'commerce_weavers_sylius_tpay.tpay.factory.create_redirect_based_payment_payload')
     ;
 
     $services->set('commerce_weavers_sylius_tpay.tpay.factory.create_pay_by_link_payment_payload', CreatePayByLinkPayloadFactory::class)
         ->args([
             service('commerce_weavers_sylius_tpay.tpay.factory.create_redirect_based_payment_payload'),
         ])
-        ->alias(CreatePayByLinkPayloadFactoryInterface::class, 'commerce_weavers_sylius_tpay.factory.create_pay_by_link_payment_payload')
+        ->alias(CreatePayByLinkPayloadFactoryInterface::class, 'commerce_weavers_sylius_tpay.tpay.factory.create_pay_by_link_payment_payload')
     ;
 
     $services->set('commerce_weavers_sylius_tpay.tpay.security.notification.factory.basic_payment', BasicPaymentFactory::class)
-        ->alias(BasicPaymentFactory::class, 'commerce_weavers_sylius_tpay.security.notification.factory.basic_payment')
+        ->alias(BasicPaymentFactory::class, 'commerce_weavers_sylius_tpay.tpay.security.notification.factory.basic_payment')
     ;
 
     $services->set('commerce_weavers_sylius_tpay.tpay.security.notification.factory.x509', X509Factory::class)
-        ->alias(X509FactoryInterface::class, 'commerce_weavers_sylius_tpay.security.notification.factory.x509')
+        ->alias(X509FactoryInterface::class, 'commerce_weavers_sylius_tpay.tpay.security.notification.factory.x509')
     ;
 
     $services->set('commerce_weavers_sylius_tpay.tpay.security.notification.resolver.certificate', CertificateResolver::class)
-        ->alias(CertificateResolverInterface::class, 'commerce_weavers_sylius_tpay.security.notification.resolver.certificate')
+        ->alias(CertificateResolverInterface::class, 'commerce_weavers_sylius_tpay.tpay.security.notification.resolver.certificate')
     ;
 
     $services->set('commerce_weavers_sylius_tpay.tpay.security.notification.resolver.cached_certificate', CachedCertificateResolver::class)
@@ -85,7 +85,7 @@ return static function(ContainerConfigurator $container): void {
     ;
 
     $services->set('commerce_weavers_sylius_tpay.tpay.security.notification.resolver.trusted_certificate', TrustedCertificateResolver::class)
-        ->alias(TrustedCertificateResolverInterface::class, 'commerce_weavers_sylius_tpay.security.notification.resolver.trusted_certificate')
+        ->alias(TrustedCertificateResolverInterface::class, 'commerce_weavers_sylius_tpay.tpay.security.notification.resolver.trusted_certificate')
     ;
 
     $services->set('commerce_weavers_sylius_tpay.tpay.security.notification.resolver.cached_trusted_certificate', CachedTrustedCertificateResolver::class)
@@ -98,7 +98,7 @@ return static function(ContainerConfigurator $container): void {
     ;
 
     $services->set('commerce_weavers_sylius_tpay.tpay.security.notification.verifier.checksum', ChecksumVerifier::class)
-        ->alias(ChecksumVerifierInterface::class, 'commerce_weavers_sylius_tpay.security.notification.verifier.checksum')
+        ->alias(ChecksumVerifierInterface::class, 'commerce_weavers_sylius_tpay.tpay.security.notification.verifier.checksum')
     ;
 
     $services->set('commerce_weavers_sylius_tpay.tpay.security.notification.verifier.signature', SignatureVerifier::class)
@@ -107,21 +107,21 @@ return static function(ContainerConfigurator $container): void {
             service('commerce_weavers_sylius_tpay.tpay.security.notification.resolver.trusted_certificate'),
             service('commerce_weavers_sylius_tpay.tpay.security.notification.factory.x509'),
         ])
-        ->alias(SignatureVerifierInterface::class, 'commerce_weavers_sylius_tpay.security.notification.verifier.signature')
+        ->alias(SignatureVerifierInterface::class, 'commerce_weavers_sylius_tpay.tpay.security.notification.verifier.signature')
     ;
 
     $services->set('commerce_weavers_sylius_tpay.tpay.provider.tpay_api_bank_list', TpayApiBankListProvider::class)
         ->args([
             service('commerce_weavers_sylius_tpay.tpay.resolver.tpay_transaction_channel_resolver'),
         ])
-        ->alias(TpayApiBankListProviderInterface::class, 'commerce_weavers_sylius_tpay.provider.tpay_api_bank_list')
+        ->alias(TpayApiBankListProviderInterface::class, 'commerce_weavers_sylius_tpay.tpay.provider.tpay_api_bank_list')
     ;
 
     $services->set('commerce_weavers_sylius_tpay.tpay.resolver.tpay_transaction_channel_resolver', TpayTransactionChannelResolver::class)
         ->args([
             service('payum'),
         ])
-        ->alias(TpayApiBankListProviderInterface::class, 'commerce_weavers_sylius_tpay.resolver.tpay_transaction_channel_resolver')
+        ->alias(TpayApiBankListProviderInterface::class, 'commerce_weavers_sylius_tpay.tpay.resolver.tpay_transaction_channel_resolver')
     ;
 
     $services->set('commerce_weavers_sylius_tpay.tpay.resolver.cached_tpay_transaction_channel_resolver', CachedTpayTransactionChannelResolver::class)

--- a/config/validation/Pay.xml
+++ b/config/validation/Pay.xml
@@ -3,12 +3,12 @@
     <class name="CommerceWeavers\SyliusTpayPlugin\Api\Command\Pay">
         <constraint name="CommerceWeavers\SyliusTpayPlugin\Api\Validator\Constraint\BlikTokenRequired">
             <option name="groups">
-                <value>commerce_weavers_tpay:shop:order:pay</value>
+                <value>commerce_weavers_sylius_tpay:shop:order:pay</value>
             </option>
         </constraint>
         <constraint name="CommerceWeavers\SyliusTpayPlugin\Api\Validator\Constraint\EncodedCardDataRequired">
             <option name="groups">
-                <value>commerce_weavers_tpay:shop:order:pay</value>
+                <value>commerce_weavers_sylius_tpay:shop:order:pay</value>
             </option>
         </constraint>
         <property name="blikToken">
@@ -16,7 +16,7 @@
                 <option name="value">6</option>
                 <option name="exactMessage">commerce_weavers_sylius_tpay.shop.pay.blik.length</option>
                 <option name="groups">
-                    <value>commerce_weavers_tpay:shop:order:pay</value>
+                    <value>commerce_weavers_sylius_tpay:shop:order:pay</value>
                 </option>
             </constraint>
         </property>
@@ -25,7 +25,7 @@
                 <option name="min">1</option>
                 <option name="minMessage">commerce_weavers_sylius_tpay.shop.pay.encoded_card_data.length</option>
                 <option name="groups">
-                    <value>commerce_weavers_tpay:shop:order:pay</value>
+                    <value>commerce_weavers_sylius_tpay:shop:order:pay</value>
                 </option>
             </constraint>
         </property>

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ class CommerceWeaversSyliusTpay {
 
     const shopConfig = Encore.getWebpackConfig();
 
-    shopConfig.name = 'commerce_weavers_tpay_shop';
+    shopConfig.name = 'commerce_weavers_sylius_tpay_shop';
 
     Encore.reset();
 

--- a/src/Routing.php
+++ b/src/Routing.php
@@ -6,11 +6,11 @@ namespace CommerceWeavers\SyliusTpayPlugin;
 
 final class Routing
 {
-    public const WEBHOOK_PAYMENT_NOTIFICATION = 'commerce_weavers_tpay_payment_notification';
+    public const WEBHOOK_PAYMENT_NOTIFICATION = 'commerce_weavers_sylius_tpay_payment_notification';
 
     public const WEBHOOK_PAYMENT_NOTIFICATION_PATH = '/webhook/{_locale}/tpay/payment-notification';
 
-    public const SHOP_WAITING_FOR_PAYMENT = 'commerce_weavers_tpay_waiting_for_payment';
+    public const SHOP_WAITING_FOR_PAYMENT = 'commerce_weavers_sylius_tpay_waiting_for_payment';
 
     public const SHOP_WAITING_FOR_PAYMENT_PATH = '/tpay/waiting-for-payment';
 }

--- a/src/Tpay/Resolver/CachedTpayTransactionChannelResolver.php
+++ b/src/Tpay/Resolver/CachedTpayTransactionChannelResolver.php
@@ -10,7 +10,7 @@ use Webmozart\Assert\Assert;
 
 final class CachedTpayTransactionChannelResolver implements TpayTransactionChannelResolverInterface
 {
-    public const COMMERCE_WEAVERS_TPAY_TRANSACTION_CHANNELS = 'commerce_wavers_tpay_transaction_channels';
+    public const COMMERCE_WEAVERS_SYLIUS_TPAY_TRANSACTION_CHANNELS = 'commerce_wavers_tpay_transaction_channels';
 
     public function __construct(
         private readonly TpayTransactionChannelResolver $decorated,
@@ -21,7 +21,7 @@ final class CachedTpayTransactionChannelResolver implements TpayTransactionChann
 
     public function resolve(): array
     {
-        $result = $this->cache->get(self::COMMERCE_WEAVERS_TPAY_TRANSACTION_CHANNELS, function (ItemInterface $item): array {
+        $result = $this->cache->get(self::COMMERCE_WEAVERS_SYLIUS_TPAY_TRANSACTION_CHANNELS, function (ItemInterface $item): array {
             $item->expiresAfter($this->cacheTtlInSeconds);
 
             return $this->decorated->resolve();

--- a/src/Tpay/Security/Notification/Resolver/CachedCertificateResolver.php
+++ b/src/Tpay/Security/Notification/Resolver/CachedCertificateResolver.php
@@ -9,7 +9,7 @@ use Symfony\Contracts\Cache\ItemInterface;
 
 final class CachedCertificateResolver implements CertificateResolverInterface
 {
-    public const COMMERCE_WEAVERS_TPAY_CERTIFICATE = 'commerce_weavers_tpay_certificate';
+    public const COMMERCE_WEAVERS_SYLIUS_TPAY_CERTIFICATE = 'commerce_weavers_sylius_tpay_certificate';
 
     public function __construct(
         private readonly CacheInterface $cache,
@@ -20,7 +20,7 @@ final class CachedCertificateResolver implements CertificateResolverInterface
 
     public function resolve(string $x5u): string
     {
-        $certificate = $this->cache->get(self::COMMERCE_WEAVERS_TPAY_CERTIFICATE, function (ItemInterface $item) use ($x5u) {
+        $certificate = $this->cache->get(self::COMMERCE_WEAVERS_SYLIUS_TPAY_CERTIFICATE, function (ItemInterface $item) use ($x5u) {
             $item->expiresAfter($this->cacheTtlInSeconds);
 
             return $this->decorated->resolve($x5u);

--- a/src/Tpay/Security/Notification/Resolver/CachedTrustedCertificateResolver.php
+++ b/src/Tpay/Security/Notification/Resolver/CachedTrustedCertificateResolver.php
@@ -9,7 +9,7 @@ use Symfony\Contracts\Cache\ItemInterface;
 
 final class CachedTrustedCertificateResolver implements TrustedCertificateResolverInterface
 {
-    public const COMMERCE_WEAVERS_TPAY_CERTIFICATE = 'commerce_weavers_tpay_trusted_certificate';
+    public const COMMERCE_WEAVERS_SYLIUS_TPAY_CERTIFICATE = 'commerce_weavers_sylius_tpay_trusted_certificate';
 
     public function __construct(
         private readonly CacheInterface $cache,
@@ -20,7 +20,7 @@ final class CachedTrustedCertificateResolver implements TrustedCertificateResolv
 
     public function resolve(bool $production = false): string
     {
-        $certificate = $this->cache->get(self::COMMERCE_WEAVERS_TPAY_CERTIFICATE, function (ItemInterface $item) use ($production) {
+        $certificate = $this->cache->get(self::COMMERCE_WEAVERS_SYLIUS_TPAY_CERTIFICATE, function (ItemInterface $item) use ($production) {
             $item->expiresAfter($this->cacheTtlInSeconds);
 
             return $this->decorated->resolve($production);

--- a/templates/shop/cart/complete/waiting_for_payment.html.twig
+++ b/templates/shop/cart/complete/waiting_for_payment.html.twig
@@ -8,7 +8,7 @@
     </h1>
 
     <div class="ui basic segment">
-        <img class="ui centered image" src="{{ asset('build/commerce-weavers/tpay/shop/images/hourglass.gif', 'commerce_weavers_tpay_shop') }}" />
+        <img class="ui centered image" src="{{ asset('build/commerce-weavers/tpay/shop/images/hourglass.gif', 'commerce_weavers_sylius_tpay_shop') }}" />
     </div>
 
     <meta http-equiv="refresh" content="{{ refreshInterval }}">

--- a/templates/shop/scripts.html.twig
+++ b/templates/shop/scripts.html.twig
@@ -1,3 +1,3 @@
 {% if app.request().attributes.get('_route') == 'sylius_shop_checkout_complete' %}
-    {{ encore_entry_script_tags('commerce-weavers-tpay-shop-entry', null, 'commerce_weavers_tpay_shop') }}
+    {{ encore_entry_script_tags('commerce-weavers-tpay-shop-entry', null, 'commerce_weavers_sylius_tpay_shop') }}
 {% endif %}

--- a/templates/shop/styles.html.twig
+++ b/templates/shop/styles.html.twig
@@ -1,3 +1,3 @@
 {% if app.request().attributes.get('_route') == 'sylius_shop_checkout_complete' %}
-    {{ encore_entry_link_tags('commerce-weavers-tpay-shop-entry', null, 'commerce_weavers_tpay_shop') }}
+    {{ encore_entry_link_tags('commerce-weavers-tpay-shop-entry', null, 'commerce_weavers_sylius_tpay_shop') }}
 {% endif %}

--- a/tests/Application/config/routes/commerce_weavers_tpay.yaml
+++ b/tests/Application/config/routes/commerce_weavers_tpay.yaml
@@ -1,7 +1,7 @@
-commerce_weavers_tpay_webhook:
+commerce_weavers_sylius_tpay_webhook:
     resource: "@CommerceWeaversSyliusTpayPlugin/config/routes_webhook.php"
 
-commerce_weavers_tpay_shop:
+commerce_weavers_sylius_tpay_shop:
     resource: "@CommerceWeaversSyliusTpayPlugin/config/routes_shop.php"
     prefix: /{_locale}
     requirements:

--- a/tests/Unit/Payum/Action/ResolveNextRouteActionTest.php
+++ b/tests/Unit/Payum/Action/ResolveNextRouteActionTest.php
@@ -93,7 +93,7 @@ final class ResolveNextRouteActionTest extends TestCase
         $action = $this->createTestSubject();
         $action->execute($this->request->reveal());
 
-        $this->request->setRouteName('commerce_weavers_tpay_waiting_for_payment')->shouldHaveBeenCalled();
+        $this->request->setRouteName('commerce_weavers_sylius_tpay_waiting_for_payment')->shouldHaveBeenCalled();
         $this->request->setRouteParameters(['payum_token' => 'token_hash'])->shouldHaveBeenCalled();
     }
 

--- a/tests/Unit/Tpay/Security/Notification/Resolver/CachedCertificateResolverTest.php
+++ b/tests/Unit/Tpay/Security/Notification/Resolver/CachedCertificateResolverTest.php
@@ -29,7 +29,7 @@ final class CachedCertificateResolverTest extends TestCase
     public function test_it_caches_certificate(): void
     {
         $this->cache
-            ->get('commerce_weavers_tpay_certificate', Argument::type('callable'))
+            ->get('commerce_weavers_sylius_tpay_certificate', Argument::type('callable'))
             ->shouldBeCalled()
             ->willReturn('certificate')
         ;
@@ -42,7 +42,7 @@ final class CachedCertificateResolverTest extends TestCase
     public function test_it_throws_an_exception_if_resolved_certificate_is_not_a_string(): void
     {
         $this->cache
-            ->get('commerce_weavers_tpay_certificate', Argument::type('callable'))
+            ->get('commerce_weavers_sylius_tpay_certificate', Argument::type('callable'))
             ->shouldBeCalled()
             ->willReturn(42)
         ;

--- a/tests/Unit/Tpay/Security/Notification/Resolver/CachedTrustedCertificateResolverTest.php
+++ b/tests/Unit/Tpay/Security/Notification/Resolver/CachedTrustedCertificateResolverTest.php
@@ -29,7 +29,7 @@ final class CachedTrustedCertificateResolverTest extends TestCase
     public function test_it_caches_trusted_certificate(): void
     {
         $this->cache
-            ->get('commerce_weavers_tpay_trusted_certificate', Argument::type('callable'))
+            ->get('commerce_weavers_sylius_tpay_trusted_certificate', Argument::type('callable'))
             ->shouldBeCalled()
             ->willReturn('trusted_certificate')
         ;
@@ -42,7 +42,7 @@ final class CachedTrustedCertificateResolverTest extends TestCase
     public function test_it_throws_an_exception_if_resolved_certificate_is_not_a_string(): void
     {
         $this->cache
-            ->get('commerce_weavers_tpay_trusted_certificate', Argument::type('callable'))
+            ->get('commerce_weavers_sylius_tpay_trusted_certificate', Argument::type('callable'))
             ->shouldBeCalled()
             ->willReturn(42)
         ;


### PR DESCRIPTION
Rename services, variables etc. named 'commerce_weavers.tpay' or 'commerce_weavers_tpay' to 'commerce_weavers_sylius_tpay'

Closes #29 