### PR TITLE
Fix providing empty fields while configuring Tpay gateway

### DIFF
--- a/src/Form/Type/TpayGatewayConfigurationType.php
+++ b/src/Form/Type/TpayGatewayConfigurationType.php
@@ -72,6 +72,7 @@ final class TpayGatewayConfigurationType extends AbstractType
                 'merchant_id',
                 TextType::class,
                 [
+                    'empty_data' => '',
                     'label' => 'commerce_weavers_sylius_tpay.admin.gateway_configuration.merchant_id',
                 ],
             )
@@ -79,6 +80,7 @@ final class TpayGatewayConfigurationType extends AbstractType
                 'google_merchant_id',
                 TextType::class,
                 [
+                    'empty_data' => '',
                     'label' => 'commerce_weavers_sylius_tpay.admin.gateway_configuration.google_merchant_id',
                 ],
             )
@@ -86,6 +88,7 @@ final class TpayGatewayConfigurationType extends AbstractType
                 'apple_pay_merchant_id',
                 TextType::class,
                 [
+                    'empty_data' => '',
                     'label' => 'commerce_weavers_sylius_tpay.admin.gateway_configuration.apple_pay_merchant_id',
                 ],
             )
@@ -93,6 +96,7 @@ final class TpayGatewayConfigurationType extends AbstractType
                 'notification_security_code',
                 PasswordType::class,
                 [
+                    'empty_data' => '',
                     'label' => 'commerce_weavers_sylius_tpay.admin.gateway_configuration.notification_security_code',
                 ],
             )


### PR DESCRIPTION
Due to encrypting, leaving an empty fields was resulting in `500` error; This PR replaces nulls with `''` on an empty value.

![CleanShot 2024-10-22 at 11 58 36](https://github.com/user-attachments/assets/cdbc5afc-fc2d-4403-b6ad-a0a6396b8a59)
