### PR TITLE
Add selecting a country phone number prefix

### DIFF
--- a/assets/shop/js/_visa_mobile.js
+++ b/assets/shop/js/_visa_mobile.js
@@ -1,3 +1,6 @@
+import 'intl-tel-input/build/css/intlTelInput.css';
+import intlTelInput from 'intl-tel-input';
+
 document.addEventListener('DOMContentLoaded', () => {
   const MOBILE_PHONE_MIN_LENGTH = 7;
   const MOBILE_PHONE_MAX_LENGTH = 15;
@@ -9,6 +12,18 @@ document.addEventListener('DOMContentLoaded', () => {
   if (null === phoneNumber) {
     return;
   }
+
+  phoneNumber.addEventListener('keypress', function(e) {
+    if (!/[0-9]/.test(e.key)) {
+      e.preventDefault();
+    }
+  });
+
+  const intlPhoneNumber = intlTelInput(phoneNumber, {
+    initialCountry: 'pl',
+    loadUtilsOnInit: () => import("intl-tel-input/utils"),
+    formatAsYouType: false,
+  });
 
   form.addEventListener('submit', (event) => {
     validateVisaMobilePhoneNumber(phoneNumber);
@@ -24,6 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
+    phoneNumber.value = intlPhoneNumber.getNumber().substring(1);
 
     form.submit();
   });

--- a/package.json
+++ b/package.json
@@ -1,22 +1,15 @@
 {
-    "devDependencies": {
-        "@babel/core": "^7.17.0",
-        "@babel/preset-env": "^7.16.0",
-        "@hotwired/stimulus": "^3.0.0",
-        "@symfony/stimulus-bridge": "^3.2.0",
-        "@symfony/webpack-encore": "^4.0.0",
-        "core-js": "^3.23.0",
-        "regenerator-runtime": "^0.13.9",
-        "webpack": "^5.74.0",
-        "webpack-cli": "^4.10.0",
-        "webpack-notifier": "^1.15.0"
+    "name": "@commerce-weavers/sylius-tpay",
+    "description": "Tpay integration for Sylius",
+    "version": "1.0.0",
+    "dependencies": {
+      "intl-tel-input": "^24.6.0"
     },
-    "license": "UNLICENSED",
-    "private": true,
-    "scripts": {
-        "dev-server": "encore dev-server",
-        "dev": "encore dev",
-        "watch": "encore dev --watch",
-        "build": "encore production --progress"
-    }
+    "files": [
+      "./package.json",
+      "./README.md",
+      "./LICENSE",
+      "./assets/"
+    ],
+    "private": true
 }

--- a/templates/shop/cart/complete/_visaMobile.html.twig
+++ b/templates/shop/cart/complete/_visaMobile.html.twig
@@ -11,7 +11,6 @@
                     <div class="field required" data-tpay-field>
                         {{ form_label(form.tpay.visa_mobile_phone_number) }}
                         <div class="ui left labeled input">
-                            <div class="ui label">+</div>
                             {{ form_widget(form.tpay.visa_mobile_phone_number, {
                                 attr: {
                                     'data-validation-error-min-length': 'commerce_weavers_sylius_tpay.shop.pay.visa_mobile.min_length'|trans({}, 'validators'),

--- a/templates/shop/payment/_visaMobile.html.twig
+++ b/templates/shop/payment/_visaMobile.html.twig
@@ -5,7 +5,6 @@
             <div class="field required" data-tpay-field>
                 {{ form_label(form.tpay.visa_mobile_phone_number) }}
                 <div class="ui left labeled input">
-                    <div class="ui label">+</div>
                     {{ form_widget(form.tpay.visa_mobile_phone_number, {
                         attr: {
                             'data-validation-error-min-length': 'commerce_weavers_sylius_tpay.shop.pay.visa_mobile.min_length'|trans({}, 'validators'),

--- a/tests/Application/package.json
+++ b/tests/Application/package.json
@@ -8,6 +8,7 @@
     "watch": "encore dev --watch"
   },
   "devDependencies": {
-    "@sylius-ui/frontend": "^1.0"
+    "@sylius-ui/frontend": "^1.0",
+    "@commerce-weavers/sylius-tpay": "file:../../"
   }
 }

--- a/tests/E2E/Checkout/TpayVisaMobileCheckoutTest.php
+++ b/tests/E2E/Checkout/TpayVisaMobileCheckoutTest.php
@@ -59,20 +59,6 @@ final class TpayVisaMobileCheckoutTest extends E2ETestCase
         $this->assertSame($inputValueMaxLength, strlen($expectedValue));
     }
 
-    public function test_it_throws_validation_error_if_phone_number_contains_non_digit_character(): void
-    {
-        $this->processWithPaymentMethod('tpay_visa_mobile');
-        $this->fillVisaMobile(self::FORM_ID, '+12312312');
-        $this->placeOrder();
-
-        $validationElement = $this->findElementByXpath("//div[contains(@class, 'sylius-validation-error')]");
-        $this->assertNotNull($validationElement);
-        $this->assertSame(
-            "The mobile phone must consist only of digits.",
-            $validationElement->getText()
-        );
-    }
-
     public function test_it_throws_validation_error_if_phone_number_is_empty(): void
     {
         $this->processWithPaymentMethod('tpay_visa_mobile');


### PR DESCRIPTION
![CleanShot 2024-10-30 at 03 50 58@2x](https://github.com/user-attachments/assets/9c522fe5-0a05-4772-9bba-9f105e07988d)

After submitting a form there's a few seconds in which we might notice that the phone number if prefixed e.g. with `48` for Poland. We might get rid of it later, for now it doesn't make any troubles.