### PR TITLE
Remove visa mobile onsite in pbl if there is one enabled

### DIFF
--- a/src/Tpay/PayGroup.php
+++ b/src/Tpay/PayGroup.php
@@ -15,4 +15,6 @@ class PayGroup
     public const GOOGLE_PAY = 166;
 
     public const VISA_MOBILE = 171;
+
+    public const VISA_MOBILE_ON_SITE = 177;
 }

--- a/src/Tpay/Provider/ValidTpayChannelListProvider.php
+++ b/src/Tpay/Provider/ValidTpayChannelListProvider.php
@@ -59,7 +59,11 @@ final class ValidTpayChannelListProvider implements ValidTpayChannelListProvider
             }
 
             match ($config['type']) {
-                PaymentType::VISA_MOBILE => $paymentMethodsToRemoveByGroupId[] = PayGroup::VISA_MOBILE,
+                PaymentType::VISA_MOBILE => array_push(
+                    $paymentMethodsToRemoveByGroupId,
+                    PayGroup::VISA_MOBILE,
+                    PayGroup::VISA_MOBILE_ON_SITE,
+                ),
                 PaymentType::APPLE_PAY => $paymentMethodsToRemoveByGroupId[] = PayGroup::APPLE_PAY,
                 PaymentType::GOOGLE_PAY => $paymentMethodsToRemoveByGroupId[] = PayGroup::GOOGLE_PAY,
                 PaymentType::BLIK => $paymentMethodsToRemoveByGroupId[] = PayGroup::BLIK,

--- a/tests/Unit/Tpay/Provider/ValidTpayChannelListProviderTest.php
+++ b/tests/Unit/Tpay/Provider/ValidTpayChannelListProviderTest.php
@@ -70,6 +70,14 @@ final class ValidTpayChannelListProviderTest extends TestCase
                 ['id' => '171'],
             ],
         ],
+        '7' => [
+            'id' => '7',
+            'name' => 'Visa mobile on site',
+            'available' => true,
+            'groups' => [
+                ['id' => '177'],
+            ],
+        ],
     ];
 
     private AvailableTpayChannelListProviderInterface|ObjectProphecy $availableTpayApiBankListProvider;
@@ -201,7 +209,8 @@ final class ValidTpayChannelListProviderTest extends TestCase
         $result = $this->createTestSubject()->provide();
 
         $expected = self::BANK_LIST;
-        unset($expected['6']);
+        // unsets both methods for visa mobile and its onsite version
+        unset($expected['6'], $expected['7']);
 
         $this->assertSame($expected, $result);
     }


### PR DESCRIPTION
resolves #165 

After (no more Visa on bottom):

![image](https://github.com/user-attachments/assets/400e336a-6616-4d0e-b7bf-53c0c6274f63)
