### PR TITLE
Set default state machine env in test app

### DIFF
--- a/tests/Application/config/packages/_sylius.yaml
+++ b/tests/Application/config/packages/_sylius.yaml
@@ -8,6 +8,7 @@ imports:
     - { resource: "@SyliusApiBundle/Resources/config/app/config.yaml" }
 
 parameters:
+    env(STATE_MACHINE_DEFAULT_ADAPTER): 'winzou_state_machine'
     sylius_core.public_dir: '%kernel.project_dir%/public'
 
 sylius_shop:


### PR DESCRIPTION
I bring this parameter back into the test app since it is needed for its configuration.