### PR TITLE
Prepend Winzou SM refund payment graph only if Sylius Refund installed

### DIFF
--- a/src/DependencyInjection/CompilerPass/AddWinzouStateMachineConfigurationPass.php
+++ b/src/DependencyInjection/CompilerPass/AddWinzouStateMachineConfigurationPass.php
@@ -43,7 +43,10 @@ final class AddWinzouStateMachineConfigurationPass implements CompilerPassInterf
             ]);
         }
 
-        if ($this->hasWinzouStateMachineGraph('sylius_refund_refund_payment', $stateMachineDefaultAdapter, $stateMachineAdapterMapping)) {
+        if (
+            $container->hasExtension('sylius_refund') &&
+            $this->hasWinzouStateMachineGraph('sylius_refund_refund_payment', $stateMachineDefaultAdapter, $stateMachineAdapterMapping)
+        ) {
             $container->prependExtensionConfig('winzou_state_machine', [
                 'sylius_refund_refund_payment' => [
                     'callbacks' => [


### PR DESCRIPTION
With no Sylius Refund installed, prepending the `winzou_state_machine.sylius_refund_refund_payment` config will fail at the and, as the config is not complete.