### PR TITLE
Allow defining a Tpay channel ID in Pay By Link

### DIFF
--- a/UPGRADE-1.1.md
+++ b/UPGRADE-1.1.md
@@ -1,0 +1,37 @@
+# UPGRADE FROM `1.0` TO `1.1`
+
+1. The `cw.tpay.admin.payment_method.form` template event has been added to the
+   `templates/bundles/SyliusAdminBundle/PaymentMethod/_form.html.twig` template. Apply the following customization to 
+   your project:
+
+```diff
+{# templates/bundles/SyliusAdminBundle/PaymentMethod/_form.html.twig #}
+
+{# ... #}
+
+<div class="ui segment">
+    <h4 class="ui dividing header">{{ 'sylius.ui.gateway_configuration'|trans }}</h4>
+
+    {# ... #}
+
++    {# >>> SyliusTpayPlugin customization #}
++    {{ sylius_template_event('cw.tpay.admin.payment_method.form', _context) }}
++    {# SyliusTpayPlugin customization <<< #}
+</div>
+
+{# ... #}
+```
+
+1. Add an admin Webpack config to your `webpack.config.js` file:
+
+```diff
+// webpack.config.js
+
+// ...
+
+const cwTpayShop = CommerceWeaversSyliusTpay.getWebpackShopConfig(path.resolve(__dirname));
++const cwTpayAdmin = CommerceWeaversSyliusTpay.getWebpackAdminConfig(path.resolve(__dirname));
+
+-module.exports = [shopConfig, adminConfig, cwTpayShop];
++module.exports = [shopConfig, adminConfig, cwTpayShop, cwTpayAdmin];
+```

--- a/assets/admin/js/test_payment_method_connection.js
+++ b/assets/admin/js/test_payment_method_connection.js
@@ -57,6 +57,7 @@ function convertTpayChannelIdInputIntoSelect(channels) {
   if (tpayChannelIdFormType.tagName.toLowerCase() === 'input' && tpayChannelIdFormType.type === 'text') {
     const select = document.createElement('select');
     select.name = tpayChannelIdFormType.name;
+    select.id = tpayChannelIdFormType.id;
     select.className = tpayChannelIdFormType.className;
     tpayChannelIdFormType.replaceWith(select);
     tpayChannelIdFormType = select;

--- a/assets/admin/js/test_payment_method_connection.js
+++ b/assets/admin/js/test_payment_method_connection.js
@@ -1,0 +1,78 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const testConnectionButton = document.getElementById('test-connection-button');
+  const testConnectionMessage = document.getElementById('test-connection-message');
+
+  if (testConnectionButton === null || testConnectionMessage === null) {
+    return;
+  }
+
+  testConnectionButton.addEventListener('click', function() {
+    const productionModeElement = document.getElementsByName('sylius_payment_method[gatewayConfig][config][production_mode]')[0];
+    const clientIdElement = document.getElementsByName('sylius_payment_method[gatewayConfig][config][client_id]')[0];
+    const clientSecretElement = document.getElementsByName('sylius_payment_method[gatewayConfig][config][client_secret]')[0];
+    const productionMode = productionModeElement !== undefined ? productionModeElement.value : 'false';
+    const clientId = clientIdElement !== undefined ? clientIdElement.value : '';
+    const clientSecret = clientSecretElement !== undefined ? clientSecretElement.value : '';
+
+    fetch('/admin/tpay/channels?productionMode=' + productionMode, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Client-Id': clientId,
+        'X-Client-Secret': clientSecret,
+      },
+    })
+      .then(response => {
+        const jsonResponse = response.json();
+
+        if (!response.ok) {
+          throw new Error();
+        }
+
+        return jsonResponse;
+      })
+      .then(data => {
+        convertTpayChannelIdInputIntoSelect(data);
+
+        testConnectionMessage.innerText = 'Connection test successful. Channels loaded.';
+        testConnectionMessage.classList.remove('negative');
+        testConnectionMessage.classList.add('positive');
+      })
+      .catch(() => {
+        testConnectionMessage.innerText = 'Connection test failed. Please check your credentials and try again.';
+        testConnectionMessage.classList.remove('positive');
+        testConnectionMessage.classList.add('negative');
+      })
+  });
+});
+
+function convertTpayChannelIdInputIntoSelect(channels) {
+  let tpayChannelIdFormType = document.getElementsByName('sylius_payment_method[gatewayConfig][config][tpay_channel_id]')[0];
+  if (tpayChannelIdFormType === undefined) {
+    return;
+  }
+
+  const value = tpayChannelIdFormType.value;
+
+  if (tpayChannelIdFormType.tagName.toLowerCase() === 'input' && tpayChannelIdFormType.type === 'text') {
+    const select = document.createElement('select');
+    select.name = tpayChannelIdFormType.name;
+    select.className = tpayChannelIdFormType.className;
+    tpayChannelIdFormType.replaceWith(select);
+    tpayChannelIdFormType = select;
+  }
+
+  tpayChannelIdFormType.innerHTML = '';
+
+  for (const [id, name] of Object.entries(channels)) {
+    const option = document.createElement('option');
+    option.value = id;
+    option.text = name;
+
+    if (id === value) {
+      option.selected = true;
+    }
+
+    tpayChannelIdFormType.appendChild(option);
+  }
+}

--- a/assets/admin/payment_method_entrypoint.js
+++ b/assets/admin/payment_method_entrypoint.js
@@ -1,0 +1,1 @@
+import './js/test_payment_method_connection';

--- a/assets/shop/js/retry_payment.js
+++ b/assets/shop/js/retry_payment.js
@@ -12,6 +12,15 @@ function enablePaymentDetails(element) {
     .forEach(function(element) {
       element.disabled = false;
     });
+
+  // many PBL payment methods support
+  const channelIdDataElement = element.querySelector('[data-channel-id-name]');
+  if (channelIdDataElement !== null) {
+    const channelIdInputName = channelIdDataElement.getAttribute('data-channel-id-name');
+    const channelIdInput = document.querySelector(`[name="${channelIdInputName}"]`);
+    channelIdInput.disabled = false;
+    channelIdInput.value = channelIdDataElement.getAttribute('data-channel-id-value');
+  }
 }
 
 function resolvePaymentDetailsFromPaymentMethodRadioButton(radioButton) {

--- a/config/config.php
+++ b/config/config.php
@@ -19,6 +19,7 @@ return static function(ContainerConfigurator $container): void {
         ->set('env(TPAY_APPLE_PAY_MERCHANT_ID)', '')
         ->set('env(TPAY_MERCHANT_ID)', '')
         ->set('env(TPAY_NOTIFICATION_SECURITY_CODE)', '')
+        ->set('env(TPAY_PBL_CHANNEL_ID)', '')
         ->set('commerce_weavers_sylius_tpay.certificate.cache_ttl_in_seconds', 300)
         ->set('commerce_weavers_sylius_tpay.tpay_transaction_channels.cache_ttl_in_seconds', 300)
         ->set('commerce_weavers_sylius_tpay.waiting_for_payment.refresh_interval', 5)

--- a/config/config/framework.php
+++ b/config/config/framework.php
@@ -7,6 +7,10 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Config\FrameworkConfig;
 
 return function(FrameworkConfig $framework): void {
+    $framework->assets()->package('commerce_weavers_sylius_tpay_admin', [
+        'json_manifest_path' => '%kernel.project_dir%/public/build/commerce-weavers/tpay/admin/manifest.json',
+    ]);
+
     $framework->assets()->package('commerce_weavers_sylius_tpay_shop', [
         'json_manifest_path' => '%kernel.project_dir%/public/build/commerce-weavers/tpay/shop/manifest.json',
     ]);

--- a/config/config/sylius_fixtures.php
+++ b/config/config/sylius_fixtures.php
@@ -71,8 +71,6 @@ return static function(SyliusFixturesConfig $fixtures): void {
         'production_mode' => false,
     ];
 
-    $twistoChannelId = '71';
-
     $defaultSuite->fixtures('payment_method', [
         'options' => [
             'custom' => [
@@ -111,10 +109,23 @@ return static function(SyliusFixturesConfig $fixtures): void {
                 ],
                 'pbl' => [
                     'code' => 'tpay_pbl',
-                    'name' => 'Pay by Link (Tpay)',
+                    'name' => 'Pay-by-link (Tpay)',
                     'gatewayFactory' => 'tpay_pbl',
                     'gatewayName' => 'tpay_pbl',
                     'gatewayConfig' => $tpayConfig,
+                    'channels' => [
+                        'FASHION_WEB',
+                    ],
+                    'enabled' => true,
+                ],
+                'pbl_channel' => [
+                    'code' => 'tpay_pbl_channel',
+                    'name' => 'Pay-by-link one channel (Tpay)',
+                    'gatewayFactory' => 'tpay_pbl',
+                    'gatewayName' => 'tpay_pbl',
+                    'gatewayConfig' => $tpayConfig + [
+                        'tpay_channel_id' => '%env(string:TPAY_PBL_CHANNEL_ID)%',
+                    ],
                     'channels' => [
                         'FASHION_WEB',
                     ],
@@ -148,20 +159,6 @@ return static function(SyliusFixturesConfig $fixtures): void {
                     'gatewayFactory' => 'tpay',
                     'gatewayName' => 'tpay',
                     'gatewayConfig' => $tpayConfig + ['type' => PaymentType::VISA_MOBILE],
-                    'channels' => [
-                        'FASHION_WEB',
-                    ],
-                    'enabled' => true,
-                ],
-                'pbl_twisto' => [
-                    'code' => 'tpay_pbl_twisto',
-                    'name' => 'Twisto (Tpay)',
-                    'gatewayFactory' => 'tpay',
-                    'gatewayName' => 'tpay',
-                    'gatewayConfig' => $tpayConfig + [
-                        'type' => PaymentType::PAY_BY_LINK,
-                        'tpay_channel_id' => $twistoChannelId,
-                    ],
                     'channels' => [
                         'FASHION_WEB',
                     ],

--- a/config/config/sylius_fixtures.php
+++ b/config/config/sylius_fixtures.php
@@ -71,6 +71,8 @@ return static function(SyliusFixturesConfig $fixtures): void {
         'production_mode' => false,
     ];
 
+    $twistoChannelId = '71';
+
     $defaultSuite->fixtures('payment_method', [
         'options' => [
             'custom' => [
@@ -146,6 +148,20 @@ return static function(SyliusFixturesConfig $fixtures): void {
                     'gatewayFactory' => 'tpay',
                     'gatewayName' => 'tpay',
                     'gatewayConfig' => $tpayConfig + ['type' => PaymentType::VISA_MOBILE],
+                    'channels' => [
+                        'FASHION_WEB',
+                    ],
+                    'enabled' => true,
+                ],
+                'pbl_twisto' => [
+                    'code' => 'tpay_pbl_twisto',
+                    'name' => 'Twisto (Tpay)',
+                    'gatewayFactory' => 'tpay',
+                    'gatewayName' => 'tpay',
+                    'gatewayConfig' => $tpayConfig + [
+                        'type' => PaymentType::PAY_BY_LINK,
+                        'tpay_channel_id' => $twistoChannelId,
+                    ],
                     'channels' => [
                         'FASHION_WEB',
                     ],

--- a/config/config/sylius_template_events.php
+++ b/config/config/sylius_template_events.php
@@ -82,6 +82,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                     ],
                 ],
             ],
+            'sylius.admin.layout.javascripts' => [
+                'blocks' => [
+                    'commerce_weavers_sylius_tpay_scripts' => [
+                        'template' => '@CommerceWeaversSyliusTpayPlugin/admin/scripts.html.twig',
+                    ],
+                ],
+            ],
             'sylius.shop.layout.javascripts' => [
                 'blocks' => [
                     'commerce_weavers_sylius_tpay_scripts' => [

--- a/config/config/sylius_template_events.php
+++ b/config/config/sylius_template_events.php
@@ -7,6 +7,14 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->extension('sylius_ui', [
         'events' => [
+            'cw.tpay.admin.payment_method.form' => [
+                'blocks' => [
+                    'test_connection' => [
+                        'template' => '@CommerceWeaversSyliusTpayPlugin/admin/payment_method/test_connection.html.twig',
+                        'priority' => 10,
+                    ],
+                ],
+            ],
             'cw.tpay.shop.checkout.complete.navigation' => [
                 'blocks' => [
                     'apple_pay' => [

--- a/config/config/webpack_encore.php
+++ b/config/config/webpack_encore.php
@@ -7,5 +7,6 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Config\WebpackEncoreConfig;
 
 return function(WebpackEncoreConfig $webpackEncore): void {
+    $webpackEncore->builds('commerce_weavers_sylius_tpay_admin', '%kernel.project_dir%/public/build/commerce-weavers/tpay/admin');
     $webpackEncore->builds('commerce_weavers_sylius_tpay_shop', '%kernel.project_dir%/public/build/commerce-weavers/tpay/shop');
 };

--- a/config/routes_admin.php
+++ b/config/routes_admin.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+use CommerceWeavers\SyliusTpayPlugin\Controller\TpayGetChannelsAction;
+use CommerceWeavers\SyliusTpayPlugin\Routing;
+use Symfony\Component\HttpFoundation\Request;
+
+return function(RoutingConfigurator $routes): void {
+    $routes->add(Routing::ADMIN_TPAY_CHANNELS, Routing::ADMIN_TPAY_CHANNELS_PATH)
+        ->controller(TpayGetChannelsAction::class)
+        ->methods([Request::METHOD_GET])
+    ;
+};

--- a/config/services/context_provider.php
+++ b/config/services/context_provider.php
@@ -5,17 +5,9 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use CommerceWeavers\SyliusTpayPlugin\ContextProvider\RegulationsUrlContextProvider;
-use CommerceWeavers\SyliusTpayPlugin\PayByLinkPayment\ContextProvider\BankListContextProvider;
 
 return static function(ContainerConfigurator $container): void {
     $services = $container->services();
-
-    $services->set(BankListContextProvider::class)
-        ->args([
-            service('commerce_weavers_sylius_tpay.tpay.provider.validated_tpay_api_bank_list'),
-        ])
-        ->tag('sylius.ui.template_event.context_provider')
-    ;
 
     $services->set(RegulationsUrlContextProvider::class)
         ->args([

--- a/config/services/pay_by_link_payment/context_provider.php
+++ b/config/services/pay_by_link_payment/context_provider.php
@@ -12,6 +12,7 @@ return static function(ContainerConfigurator $container): void {
     $services->set('commerce_weavers_sylius_tpay.pay_by_link_payment.context_provider.bank_list', BankListContextProvider::class)
         ->args([
             service('commerce_weavers_sylius_tpay.tpay.provider.validated_tpay_api_bank_list'),
+            service('payum.dynamic_gateways.cypher'),
         ])
         ->tag('sylius.ui.template_event.context_provider')
     ;

--- a/config/services/tpay.php
+++ b/config/services/tpay.php
@@ -20,8 +20,10 @@ use CommerceWeavers\SyliusTpayPlugin\Tpay\Factory\CreateVisaMobilePaymentPayload
 use CommerceWeavers\SyliusTpayPlugin\Tpay\Provider\AvailableTpayChannelListProvider;
 use CommerceWeavers\SyliusTpayPlugin\Tpay\Provider\AvailableTpayChannelListProviderInterface;
 use CommerceWeavers\SyliusTpayPlugin\Tpay\Provider\ValidTpayChannelListProvider;
+use CommerceWeavers\SyliusTpayPlugin\Tpay\Provider\ValidTpayChannelListProviderInterface;
 use CommerceWeavers\SyliusTpayPlugin\Tpay\Resolver\CachedTpayTransactionChannelResolver;
 use CommerceWeavers\SyliusTpayPlugin\Tpay\Resolver\TpayTransactionChannelResolver;
+use CommerceWeavers\SyliusTpayPlugin\Tpay\Resolver\TpayTransactionChannelResolverInterface;
 use CommerceWeavers\SyliusTpayPlugin\Tpay\Security\Notification\Checker\ProductionModeChecker;
 use CommerceWeavers\SyliusTpayPlugin\Tpay\Security\Notification\Checker\ProductionModeCheckerInterface;
 use CommerceWeavers\SyliusTpayPlugin\Tpay\Security\Notification\Factory\BasicPaymentFactory;
@@ -163,7 +165,7 @@ return static function(ContainerConfigurator $container): void {
             service('sylius.context.channel'),
             service('payum.dynamic_gateways.cypher')
         ])
-        ->alias(AvailableTpayChannelListProviderInterface::class, 'commerce_weavers_sylius_tpay.tpay.provider.validated_tpay_api_bank_list')
+        ->alias(ValidTpayChannelListProviderInterface::class, 'commerce_weavers_sylius_tpay.tpay.provider.validated_tpay_api_bank_list')
     ;
 
     $services->set('commerce_weavers_sylius_tpay.tpay.resolver.tpay_transaction_channel_resolver', TpayTransactionChannelResolver::class)
@@ -173,7 +175,7 @@ return static function(ContainerConfigurator $container): void {
             service('logger')->nullOnInvalid(),
         ])
         ->tag('monolog.logger', ['channel' => 'sylius_tpay'])
-        ->alias(AvailableTpayChannelListProviderInterface::class, 'commerce_weavers_sylius_tpay.tpay.resolver.tpay_transaction_channel_resolver')
+        ->alias(TpayTransactionChannelResolverInterface::class, 'commerce_weavers_sylius_tpay.tpay.resolver.tpay_transaction_channel_resolver')
     ;
 
     $services->set('commerce_weavers_sylius_tpay.tpay.resolver.cached_tpay_transaction_channel_resolver', CachedTpayTransactionChannelResolver::class)

--- a/index.js
+++ b/index.js
@@ -25,6 +25,29 @@ class CommerceWeaversSyliusTpay {
 
     return shopConfig;
   }
+
+  static getWebpackAdminConfig(rootDir) {
+    Encore
+      .setOutputPath('public/build/commerce-weavers/tpay/admin')
+      .setPublicPath('/build/commerce-weavers/tpay/admin')
+      .addEntry('commerce-weavers-sylius-tpay-admin-payment-method-entry', path.resolve(__dirname, 'assets/admin/payment_method_entrypoint.js'))
+      .disableSingleRuntimeChunk()
+      .cleanupOutputBeforeBuild()
+      .enableSourceMaps(!Encore.isProduction())
+      .enableVersioning(Encore.isProduction())
+      .enableSassLoader((options) => {
+        // eslint-disable-next-line no-param-reassign
+        options.additionalData = `$rootDir: ${rootDir};`;
+      })
+
+    const adminConfig = Encore.getWebpackConfig();
+
+    adminConfig.name = 'commerce_weavers_sylius_tpay_admin';
+
+    Encore.reset();
+
+    return adminConfig;
+  }
 }
 
 module.exports = CommerceWeaversSyliusTpay;

--- a/src/Controller/TpayGetChannelsAction.php
+++ b/src/Controller/TpayGetChannelsAction.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommerceWeavers\SyliusTpayPlugin\Controller;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Tpay\OpenApi\Api\TpayApi;
+use Tpay\OpenApi\Utilities\TpayException;
+
+final class TpayGetChannelsAction
+{
+    public function __invoke(Request $request): Response
+    {
+        $tpayApi = new TpayApi(
+            (string) $request->headers->get('X-Client-Id'),
+            (string) $request->headers->get('X-Client-Secret'),
+            $request->query->getBoolean('productionMode', true),
+        );
+
+        try {
+            $tpayResponse = $tpayApi->transactions()->getChannels();
+        } catch (TpayException $e) {
+            return new JsonResponse(['error' => $e->getMessage()], Response::HTTP_UNAUTHORIZED);
+        }
+
+        $channels = [];
+        foreach ($tpayResponse['channels'] as $channel) {
+            $channels[$channel['id']] = $channel['name'];
+        }
+
+        return new JsonResponse($channels);
+    }
+}

--- a/src/Form/Type/TpayGatewayConfigurationType.php
+++ b/src/Form/Type/TpayGatewayConfigurationType.php
@@ -111,6 +111,15 @@ final class TpayGatewayConfigurationType extends AbstractType
                 ],
             )
             ->add(
+                'tpay_channel_id',
+                TextType::class,
+                [
+                    'empty_data' => '',
+                    'label' => 'commerce_weavers_sylius_tpay.admin.gateway_configuration.tpay_channel_id',
+                    'required' => false,
+                ],
+            )
+            ->add(
                 'production_mode',
                 ChoiceType::class,
                 [

--- a/src/Form/Type/TpayGatewayConfigurationType.php
+++ b/src/Form/Type/TpayGatewayConfigurationType.php
@@ -116,6 +116,7 @@ final class TpayGatewayConfigurationType extends AbstractType
                 [
                     'empty_data' => '',
                     'label' => 'commerce_weavers_sylius_tpay.admin.gateway_configuration.tpay_channel_id',
+                    'help' => 'commerce_weavers_sylius_tpay.admin.gateway_configuration.tpay_channel_id_help',
                     'required' => false,
                 ],
             )

--- a/src/PayByLinkPayment/Form/Type/GatewayConfigurationType.php
+++ b/src/PayByLinkPayment/Form/Type/GatewayConfigurationType.php
@@ -5,7 +5,26 @@ declare(strict_types=1);
 namespace CommerceWeavers\SyliusTpayPlugin\PayByLinkPayment\Form\Type;
 
 use CommerceWeavers\SyliusTpayPlugin\Form\Type\AbstractTpayGatewayConfigurationType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
 
 final class GatewayConfigurationType extends AbstractTpayGatewayConfigurationType
 {
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        parent::buildForm($builder, $options);
+
+        $builder
+            ->add(
+                'tpay_channel_id',
+                TextType::class,
+                [
+                    'empty_data' => '',
+                    'label' => 'commerce_weavers_sylius_tpay.admin.gateway_configuration.tpay_channel_id',
+                    'help' => 'commerce_weavers_sylius_tpay.admin.gateway_configuration.tpay_channel_id_help',
+                    'required' => false,
+                ],
+            )
+        ;
+    }
 }

--- a/src/Routing.php
+++ b/src/Routing.php
@@ -18,6 +18,10 @@ final class Routing
 
     public const WEBHOOK_NOTIFICATION_PATH = '/webhook/{_locale}/tpay/notification';
 
+    public const ADMIN_TPAY_CHANNELS = 'commerce_weavers_sylius_tpay_admin_tpay_get_channels';
+
+    public const ADMIN_TPAY_CHANNELS_PATH = '/tpay/channels';
+
     public const SHOP_PAYMENT_FAILED = 'commerce_weavers_sylius_tpay_payment_failed';
 
     public const SHOP_PAYMENT_FAILED_PATH = '/tpay/order/{orderToken}/payment-failed';

--- a/templates/admin/payment_method/test_connection.html.twig
+++ b/templates/admin/payment_method/test_connection.html.twig
@@ -1,0 +1,6 @@
+{% if resource.gatewayConfig.factoryName == 'tpay' %}
+    <div class="ui compact segment" style="display: flex; align-items: center;">
+        <div class="ui button" id="test-connection-button" style="margin-right: 10px;">{{ 'commerce_weavers_sylius_tpay.admin.gateway_configuration.test_connection'|trans }}</div>
+        <div class="ui message" id="test-connection-message" style="flex-grow: 1; margin: 0;"></div>
+    </div>
+{% endif %}

--- a/templates/admin/payment_method/test_connection.html.twig
+++ b/templates/admin/payment_method/test_connection.html.twig
@@ -1,4 +1,4 @@
-{% if resource.gatewayConfig.factoryName == 'tpay' %}
+{% if resource.gatewayConfig.factoryName == 'tpay_pbl' %}
     <div class="ui compact segment" style="display: flex; align-items: center;">
         <div class="ui button" id="test-connection-button" style="margin-right: 10px;">{{ 'commerce_weavers_sylius_tpay.admin.gateway_configuration.test_connection'|trans }}</div>
         <div class="ui message" id="test-connection-message" style="flex-grow: 1; margin: 0;"></div>

--- a/templates/admin/scripts.html.twig
+++ b/templates/admin/scripts.html.twig
@@ -1,0 +1,3 @@
+{% if app.request().attributes.get('_route') in ['sylius_admin_payment_method_create', 'sylius_admin_payment_method_update'] %}
+    {{ encore_entry_script_tags('commerce-weavers-sylius-tpay-admin-payment-method-entry', null, 'commerce_weavers_sylius_tpay_admin') }}
+{% endif %}

--- a/templates/bundles/SyliusAdminBundle/PaymentMethod/_form.html.twig
+++ b/templates/bundles/SyliusAdminBundle/PaymentMethod/_form.html.twig
@@ -54,67 +54,6 @@
             <div class="ui button" id="test-connection-button" style="margin-right: 10px;">{{ 'commerce_weavers_sylius_tpay.admin.gateway_configuration.test_connection'|trans }}</div>
             <div class="ui message" id="test-connection-message" style="flex-grow: 1; margin: 0;"></div>
         </div>
-
-        <script>
-        document.getElementById('test-connection-button').addEventListener('click', function() {
-            fetch('/admin/tpay/channels?productionMode=' + document.getElementsByName('sylius_payment_method[gatewayConfig][config][production_mode]')[0].value, {
-                method: 'GET',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-Client-Id': document.getElementsByName('sylius_payment_method[gatewayConfig][config][client_id]')[0].value,
-                    'X-Client-Secret': document.getElementsByName('sylius_payment_method[gatewayConfig][config][client_secret]')[0].value,
-                },
-            })
-            .then(response => {
-                const jsonResponse = response.json();
-
-                if (!response.ok) {
-                    throw new Error();
-                }
-
-                return jsonResponse;
-            })
-            .then(data => {
-                let tpayChannelIdFormType = document.getElementsByName('sylius_payment_method[gatewayConfig][config][tpay_channel_id]')[0];
-                if (tpayChannelIdFormType === undefined) {
-                    return;
-                }
-
-                const value = tpayChannelIdFormType.value;
-
-                if (tpayChannelIdFormType.tagName.toLowerCase() === 'input' && tpayChannelIdFormType.type === 'text') {
-                    const select = document.createElement('select');
-                    select.name = tpayChannelIdFormType.name;
-                    select.className = tpayChannelIdFormType.className;
-                    tpayChannelIdFormType.replaceWith(select);
-                    tpayChannelIdFormType = select;
-                }
-
-                tpayChannelIdFormType.innerHTML = '';
-
-                for (const [id, name] of Object.entries(data)) {
-                    const option = document.createElement('option');
-                    option.value = id;
-                    option.text = name;
-
-                    if (id === value) {
-                        option.selected = true;
-                    }
-
-                    tpayChannelIdFormType.appendChild(option);
-                }
-
-                document.getElementById('test-connection-message').innerText = 'Connection test successful. Channels loaded.';
-                document.getElementById('test-connection-message').classList.remove('negative');
-                document.getElementById('test-connection-message').classList.add('positive');
-            })
-            .catch(error => {
-                document.getElementById('test-connection-message').innerText = 'Connection test failed. Please check your credentials and try again.';
-                document.getElementById('test-connection-message').classList.remove('positive');
-                document.getElementById('test-connection-message').classList.add('negative');
-            })
-        });
-        </script>
     {% endif %}
 </div>
 

--- a/templates/bundles/SyliusAdminBundle/PaymentMethod/_form.html.twig
+++ b/templates/bundles/SyliusAdminBundle/PaymentMethod/_form.html.twig
@@ -1,0 +1,138 @@
+{% import '@SyliusUi/Macro/flags.html.twig' as flags %}
+
+{{ form_errors(form) }}
+
+<div class="ui segment">
+    <h4 class="ui dividing header">{{ 'sylius.ui.details'|trans }}</h4>
+    {{ form_errors(form) }}
+
+    <div class="two fields">
+        {{ form_row(form.code) }}
+        {{ form_row(form.position) }}
+    </div>
+    {{ form_row(form.enabled) }}
+    {{ form_row(form.channels) }}
+</div>
+
+<div class="ui segment">
+    <h4 class="ui dividing header">{{ 'sylius.ui.gateway_configuration'|trans }}</h4>
+
+    {% if resource.gatewayConfig.factoryName == 'stripe_checkout' %}
+        <div class="ui icon negative orange message sylius-flash-message">
+            <i class="close icon"></i>
+            <i class="warning icon"></i>
+            <div class="content">
+                <div class="header">
+                    {{ 'sylius.ui.gateway.no_sca_support_notice'|trans }}
+                </div>
+            </div>
+        </div>
+    {% endif %}
+    {% if resource.gatewayConfig.factoryName == 'paypal_express_checkout' %}
+        <div class="ui icon negative orange message sylius-flash-message">
+            <i class="close icon"></i>
+            <i class="warning icon"></i>
+            <div class="content">
+                <div class="header">
+                    {% autoescape false %}{{ 'sylius.ui.gateway.pay_pal_express_checkout_deprecation_notice'|trans }}{% endautoescape %}
+                </div>
+            </div>
+        </div>
+    {% endif %}
+
+    {{ form_row(form.gatewayConfig.factoryName) }}
+    {% if form.gatewayConfig.config is defined %}
+        {% for field in form.gatewayConfig.config %}
+            {% if loop.index is odd and not loop.last %}<div class="two fields">{% endif %}
+            {{ form_row(field) }}
+            {% if loop.index is even %}</div>{% endif %}
+        {% endfor %}
+    {% endif %}
+
+    {% if resource.gatewayConfig.factoryName == 'tpay' %}
+        <div class="ui compact segment" style="display: flex; align-items: center;">
+            <div class="ui button" id="test-connection-button" style="margin-right: 10px;">{{ 'commerce_weavers_sylius_tpay.admin.gateway_configuration.test_connection'|trans }}</div>
+            <div class="ui message" id="test-connection-message" style="flex-grow: 1; margin: 0;"></div>
+        </div>
+
+        <script>
+        document.getElementById('test-connection-button').addEventListener('click', function() {
+            fetch('/admin/tpay/channels?productionMode=' + document.getElementsByName('sylius_payment_method[gatewayConfig][config][production_mode]')[0].value, {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Client-Id': document.getElementsByName('sylius_payment_method[gatewayConfig][config][client_id]')[0].value,
+                    'X-Client-Secret': document.getElementsByName('sylius_payment_method[gatewayConfig][config][client_secret]')[0].value,
+                },
+            })
+            .then(response => {
+                const jsonResponse = response.json();
+
+                if (!response.ok) {
+                    throw new Error();
+                }
+
+                return jsonResponse;
+            })
+            .then(data => {
+                let tpayChannelIdFormType = document.getElementsByName('sylius_payment_method[gatewayConfig][config][tpay_channel_id]')[0];
+                if (tpayChannelIdFormType === undefined) {
+                    return;
+                }
+
+                const value = tpayChannelIdFormType.value;
+
+                if (tpayChannelIdFormType.tagName.toLowerCase() === 'input' && tpayChannelIdFormType.type === 'text') {
+                    const select = document.createElement('select');
+                    select.name = tpayChannelIdFormType.name;
+                    select.className = tpayChannelIdFormType.className;
+                    tpayChannelIdFormType.replaceWith(select);
+                    tpayChannelIdFormType = select;
+                }
+
+                tpayChannelIdFormType.innerHTML = '';
+
+                for (const [id, name] of Object.entries(data)) {
+                    const option = document.createElement('option');
+                    option.value = id;
+                    option.text = name;
+
+                    if (id === value) {
+                        option.selected = true;
+                    }
+
+                    tpayChannelIdFormType.appendChild(option);
+                }
+
+                document.getElementById('test-connection-message').innerText = 'Connection test successful. Channels loaded.';
+                document.getElementById('test-connection-message').classList.remove('negative');
+                document.getElementById('test-connection-message').classList.add('positive');
+            })
+            .catch(error => {
+                document.getElementById('test-connection-message').innerText = 'Connection test failed. Please check your credentials and try again.';
+                document.getElementById('test-connection-message').classList.remove('positive');
+                document.getElementById('test-connection-message').classList.add('negative');
+            })
+        });
+        </script>
+    {% endif %}
+</div>
+
+<div class="ui styled fluid accordion">
+    {% for locale, translationForm in form.translations %}
+        <div class="title{% if loop.first %} active{% endif %}">
+            <i class="dropdown icon"></i>
+            {{ flags.fromLocaleCode(locale) }} {{ locale|sylius_locale_name }}
+        </div>
+        <div class="content{% if loop.first %} active{% endif %}">
+            {{ form_row(translationForm.name) }}
+            {{ form_row(translationForm.description) }}
+            <div class="ui compact message">
+                <p>
+                    <i class="icon info circle"></i> {{ 'sylius.ui.the_instructions_below_will_be_displayed_to_the_customer'|trans }}.
+                </p>
+            </div>
+            {{ form_row(translationForm.instructions) }}
+        </div>
+    {% endfor %}
+</div>

--- a/templates/bundles/SyliusAdminBundle/PaymentMethod/_form.html.twig
+++ b/templates/bundles/SyliusAdminBundle/PaymentMethod/_form.html.twig
@@ -49,12 +49,9 @@
         {% endfor %}
     {% endif %}
 
-    {% if resource.gatewayConfig.factoryName == 'tpay' %}
-        <div class="ui compact segment" style="display: flex; align-items: center;">
-            <div class="ui button" id="test-connection-button" style="margin-right: 10px;">{{ 'commerce_weavers_sylius_tpay.admin.gateway_configuration.test_connection'|trans }}</div>
-            <div class="ui message" id="test-connection-message" style="flex-grow: 1; margin: 0;"></div>
-        </div>
-    {% endif %}
+    {# >>> SyliusTpayPlugin customization #}
+    {{ sylius_template_event('cw.tpay.admin.payment_method.form', _context) }}
+    {# SyliusTpayPlugin customization <<< #}
 </div>
 
 <div class="ui styled fluid accordion">

--- a/templates/shop/cart/complete/_payByLink.html.twig
+++ b/templates/shop/cart/complete/_payByLink.html.twig
@@ -2,16 +2,5 @@
 
 {% if payment is not null and payment.method.gatewayConfig.gatewayName == 'tpay_pbl'
 %}
-    <div class="bank-container">
-        {% for bank in banks %}
-            <div class="bank-tile" data-bank-id="{{ bank.id }}">
-                <img src="{{ bank.image.url }}" alt="{{ bank.name }}">
-                <p>{{ bank.name }}</p>
-            </div>
-        {% endfor %}
-    </div>
-
-    {{ form_row(form.tpay.tpay_channel_id) }}
-
-    {% include '@CommerceWeaversSyliusTpayPlugin/shop/partial/_policies.html.twig' %}
+    {% include '@CommerceWeaversSyliusTpayPlugin/shop/payment/_payByLink.html.twig' %}
 {% endif %}

--- a/templates/shop/payment/_payByLink.html.twig
+++ b/templates/shop/payment/_payByLink.html.twig
@@ -8,7 +8,11 @@
         {% endfor %}
     </div>
 
-    {{ form_row(form.tpay.tpay_channel_id, { 'value': defaultTpayChannelId }) }}
+    {# many PBL payment methods support #}
+    <div data-channel-id-name="{{ form.tpay.tpay_channel_id.vars.full_name }}" data-channel-id-value="{{ defaultTpayChannelId }}"></div>
+    {% if not form.tpay.tpay_channel_id.rendered %}
+        {{ form_row(form.tpay.tpay_channel_id, {'value': defaultTpayChannelId}) }}
+    {% endif %}
 
     {% include '@CommerceWeaversSyliusTpayPlugin/shop/partial/_policies.html.twig' %}
 </div>

--- a/templates/shop/payment/_payByLink.html.twig
+++ b/templates/shop/payment/_payByLink.html.twig
@@ -8,7 +8,7 @@
         {% endfor %}
     </div>
 
-    {{ form_row(form.tpay.tpay_channel_id) }}
+    {{ form_row(form.tpay.tpay_channel_id, { 'value': defaultTpayChannelId }) }}
 
     {% include '@CommerceWeaversSyliusTpayPlugin/shop/partial/_policies.html.twig' %}
 </div>

--- a/tests/Application/.env.dev
+++ b/tests/Application/.env.dev
@@ -10,4 +10,5 @@ TPAY_NOTIFICATION_SECURITY_CODE=<edit_me>
 TPAY_MERCHANT_ID=<edit_me>
 TPAY_GOOGLE_MERCHANT_ID=<edit_me>
 TPAY_APPLE_PAY_MERCHANT_ID=<edit_me>
+TPAY_PBL_CHANNEL_ID=<edit_me>
 ###< commerce-weavers/sylius-tpay-plugin ###

--- a/tests/Application/config/routes/commerce_weavers_tpay.yaml
+++ b/tests/Application/config/routes/commerce_weavers_tpay.yaml
@@ -6,3 +6,7 @@ commerce_weavers_sylius_tpay_shop:
     prefix: /{_locale}
     requirements:
         _locale: ^[A-Za-z]{2,4}(_([A-Za-z]{4}|[0-9]{3}))?(_([A-Za-z]{2}|[0-9]{3}))?$
+        
+commerce_weavers_sylius_tpay_admin:
+    resource: "@CommerceWeaversSyliusTpayPlugin/config/routes_admin.php"
+    prefix: /admin

--- a/tests/Application/webpack.config.js
+++ b/tests/Application/webpack.config.js
@@ -51,5 +51,6 @@ adminConfig.name = 'admin';
 Encore.reset();
 
 const cwTpayShop = CommerceWeaversSyliusTpay.getWebpackShopConfig(path.resolve(__dirname));
+const cwTpayAdmin = CommerceWeaversSyliusTpay.getWebpackAdminConfig(path.resolve(__dirname));
 
-module.exports = [shopConfig, adminConfig, cwTpayShop];
+module.exports = [shopConfig, adminConfig, cwTpayShop, cwTpayAdmin];

--- a/tests/E2E/Admin/PaymentMethod/TestPaymentMethodConnectionTest.php
+++ b/tests/E2E/Admin/PaymentMethod/TestPaymentMethodConnectionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Admin\PaymentMethod;
+
+use Facebook\WebDriver\WebDriverBy;
+use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\E2ETestCase;
+use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Helper\Account\LoginAdminUserTrait;
+
+final class TestPaymentMethodConnectionTest extends E2ETestCase
+{
+    use LoginAdminUserTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadFixtures(['admin/payment_methods.yaml']);
+
+        $this->loginAdminUser('rich@example.com', 'sylius');
+    }
+
+    public function test_it_checks_if_payment_method_connection(): void
+    {
+        $this->client->request('GET', '/admin/payment-methods/new/tpay');
+
+        $this->client
+            ->findElement(WebDriverBy::id('sylius_payment_method_gatewayConfig_config_client_id'))
+            ->sendKeys(getenv('TPAY_CLIENT_ID'))
+        ;
+        $this->client
+            ->findElement(WebDriverBy::id('sylius_payment_method_gatewayConfig_config_client_secret'))
+            ->sendKeys(getenv('TPAY_CLIENT_SECRET'))
+        ;
+        $this->client
+            ->findElement(WebDriverBy::id('sylius_payment_method_gatewayConfig_config_production_mode'))
+            ->sendKeys('No')
+        ;
+        $this->client->findElement(WebDriverBy::id('test-connection-button'))->click();
+        $this->client->waitForElementToContain('#test-connection-message', 'Connection test successful. Channels loaded.');
+        $channelSelector = $this->client->findElement(WebDriverBy::id('sylius_payment_method_gatewayConfig_config_tpay_channel_id'));
+
+        $this->assertSame('select', $channelSelector->getTagName());
+    }
+}

--- a/tests/E2E/Admin/PaymentMethod/TestPaymentMethodConnectionTest.php
+++ b/tests/E2E/Admin/PaymentMethod/TestPaymentMethodConnectionTest.php
@@ -23,7 +23,7 @@ final class TestPaymentMethodConnectionTest extends E2ETestCase
 
     public function test_it_checks_if_payment_method_connection(): void
     {
-        $this->client->request('GET', '/admin/payment-methods/new/tpay');
+        $this->client->request('GET', '/admin/payment-methods/new/tpay_pbl');
 
         $this->client
             ->findElement(WebDriverBy::id('sylius_payment_method_gatewayConfig_config_client_id'))

--- a/tests/E2E/Helper/Account/LoginAdminUserTrait.php
+++ b/tests/E2E/Helper/Account/LoginAdminUserTrait.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Helper\Account;
+
+use Symfony\Component\Panther\Client;
+
+/**
+ * @property Client $client
+ */
+trait LoginAdminUserTrait
+{
+    protected function loginAdminUser(string $email, string $password): void
+    {
+        $this->client->request('GET', '/admin/login');
+        $this->client->submitForm('Login', ['_username' => $email, '_password' => $password]);
+    }
+}

--- a/tests/E2E/Resources/fixtures/admin/payment_methods.yaml
+++ b/tests/E2E/Resources/fixtures/admin/payment_methods.yaml
@@ -1,0 +1,5 @@
+include:
+    - ../common/channel.yaml
+    - ../common/country.yaml
+    - ../common/payment_method.yaml
+    - ../common/admin.yaml

--- a/tests/E2E/Resources/fixtures/common/admin.yaml
+++ b/tests/E2E/Resources/fixtures/common/admin.yaml
@@ -1,0 +1,8 @@
+Sylius\Component\Core\Model\AdminUser:
+    admin_user_rich:
+        plainPassword: sylius
+        roles: [ROLE_ADMINISTRATION_ACCESS]
+        enabled: true
+        email: "rich\\@example.com"
+        username: rich
+        localeCode: en

--- a/tests/E2E/Resources/fixtures/common/payment_method.yaml
+++ b/tests/E2E/Resources/fixtures/common/payment_method.yaml
@@ -93,8 +93,8 @@ Sylius\Bundle\PayumBundle\Model\GatewayConfig:
             production_mode: false
             encrypted: true
     gateway_tpay_pbl_one_channel:
-        gatewayName: 'tpay'
-        factoryName: 'tpay'
+        gatewayName: 'tpay_pbl'
+        factoryName: 'tpay_pbl'
         config:
             client_id: 'encrypted_<getenv("TPAY_CLIENT_ID")>'
             client_secret: 'encrypted_<getenv("TPAY_CLIENT_SECRET")>'

--- a/tests/E2E/Resources/fixtures/common/payment_method.yaml
+++ b/tests/E2E/Resources/fixtures/common/payment_method.yaml
@@ -34,6 +34,13 @@ Sylius\Component\Core\Model\PaymentMethod:
         translations:
             - '@tpay_pbl_payment_method_translation'
         channels: [ '@channel_web' ]
+    tpay_pbl_one_channel:
+        code: 'tpay_pbl_one_channel'
+        enabled: true
+        gatewayConfig: '@gateway_tpay_pbl_one_channel'
+        translations:
+            - '@tpay_pbl_one_channel_payment_method_translation'
+        channels: [ '@channel_web' ]
     tpay_visa_mobile:
         code: 'tpay_visa_mobile'
         enabled: true
@@ -85,6 +92,16 @@ Sylius\Bundle\PayumBundle\Model\GatewayConfig:
             type: 'pay_by_link'
             production_mode: false
             encrypted: true
+    gateway_tpay_pbl_one_channel:
+        gatewayName: 'tpay'
+        factoryName: 'tpay'
+        config:
+            client_id: 'encrypted_<getenv("TPAY_CLIENT_ID")>'
+            client_secret: 'encrypted_<getenv("TPAY_CLIENT_SECRET")>'
+            tpay_channel_id: '1'
+            type: 'pay_by_link'
+            production_mode: false
+            encrypted: true
     gateway_tpay_visa_mobile:
         gatewayName: 'tpay'
         factoryName: 'tpay'
@@ -117,10 +134,15 @@ Sylius\Component\Payment\Model\PaymentMethodTranslation:
         description: '<paragraph(2)>'
         translatable: '@tpay_google_pay'
     tpay_pbl_payment_method_translation:
-        name: 'Bank (Tpay)'
+        name: 'Choose bank (Tpay)'
         locale: 'en_US'
         description: '<paragraph(2)>'
         translatable: '@tpay_pbl'
+    tpay_pbl_one_channel_payment_method_translation:
+        name: 'One Bank (Tpay)'
+        locale: 'en_US'
+        description: '<paragraph(2)>'
+        translatable: '@tpay_pbl_one_channel'
     tpay_visa_mobile_payment_method_translation:
         name: 'Visa mobile (Tpay)'
         locale: 'en_US'

--- a/tests/E2E/Shop/Checkout/FreePaymentCheckoutTest.php
+++ b/tests/E2E/Shop/Checkout/FreePaymentCheckoutTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Shop\Checkout;
+
+use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\E2ETestCase;
+use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Helper\Account\LoginShopUserTrait;
+use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Helper\Order\CartTrait;
+use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Helper\Order\TpayTrait;
+
+final class FreePaymentCheckoutTest extends E2ETestCase
+{
+    use CartTrait;
+    use TpayTrait;
+    use LoginShopUserTrait;
+
+    private const FORM_ID = 'sylius_checkout_complete';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadFixtures(['addressed_free_cart.yaml']);
+
+        $this->loginShopUser('tony@nonexisting.cw', 'sylius');
+        // the cart is already addressed, so we go straight to selecting a shipping method
+        $this->showSelectingShippingMethodStep();
+        $this->processWithDefaultShippingMethod();
+    }
+
+    public function test_it_completes_the_checkout_if_order_total_is_0(): void
+    {
+        // total is 0.00 so we do not choose payment method and go straight to complete
+        $this->placeOrder();
+
+        $this->assertPageTitleContains('Thank you!');
+    }
+}

--- a/tests/E2E/Shop/Checkout/TpayCreditCardCheckoutTest.php
+++ b/tests/E2E/Shop/Checkout/TpayCreditCardCheckoutTest.php
@@ -2,9 +2,8 @@
 
 declare(strict_types=1);
 
-namespace E2E\Checkout;
+namespace Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Shop\Checkout;
 
-use Facebook\WebDriver\Exception\NoSuchElementException;
 use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\E2ETestCase;
 use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Helper\Account\LoginShopUserTrait;
 use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Helper\Order\CartTrait;

--- a/tests/E2E/Shop/Checkout/TpayPayByLinkCheckoutTest.php
+++ b/tests/E2E/Shop/Checkout/TpayPayByLinkCheckoutTest.php
@@ -2,14 +2,15 @@
 
 declare(strict_types=1);
 
-namespace E2E\Checkout;
+namespace Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Shop\Checkout;
 
+use Facebook\WebDriver\WebDriverBy;
 use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\E2ETestCase;
 use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Helper\Account\LoginShopUserTrait;
 use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Helper\Order\CartTrait;
 use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Helper\Order\TpayTrait;
 
-final class FreePaymentCheckoutTest extends E2ETestCase
+final class TpayPayByLinkCheckoutTest extends E2ETestCase
 {
     use CartTrait;
     use TpayTrait;
@@ -21,17 +22,25 @@ final class FreePaymentCheckoutTest extends E2ETestCase
     {
         parent::setUp();
 
-        $this->loadFixtures(['addressed_free_cart.yaml']);
+        $this->loadFixtures(['addressed_cart.yaml']);
 
         $this->loginShopUser('tony@nonexisting.cw', 'sylius');
-        // the cart is already addressed, so we go straight to selecting a shipping method
         $this->showSelectingShippingMethodStep();
         $this->processWithDefaultShippingMethod();
     }
 
-    public function test_it_completes_the_checkout_if_order_total_is_0(): void
+    public function test_it_completes_the_checkout_using_pay_by_link_channel_selection(): void
     {
-        // total is 0.00 so we do not choose payment method and go straight to complete
+        $this->processWithPaymentMethod('tpay_pbl');
+        $this->client->findElement(WebDriverBy::xpath("//div[@data-bank-id='1']"))->click();
+        $this->placeOrder();
+
+        $this->assertPageTitleContains('Thank you!');
+    }
+
+    public function test_it_completes_the_checkout_using_pay_by_link_channel_preselected(): void
+    {
+        $this->processWithPaymentMethod('tpay_pbl_one_channel');
         $this->placeOrder();
 
         $this->assertPageTitleContains('Thank you!');

--- a/tests/E2E/Shop/Checkout/TpayPaymentCheckoutTest.php
+++ b/tests/E2E/Shop/Checkout/TpayPaymentCheckoutTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Checkout;
+namespace Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Shop\Checkout;
 
 use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\E2ETestCase;
 use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Helper\Account\LoginShopUserTrait;
@@ -16,8 +16,6 @@ final class TpayPaymentCheckoutTest extends E2ETestCase
     use LoginShopUserTrait;
 
     private const FORM_ID = 'sylius_checkout_complete';
-
-    private const CARD_NUMBER = '4012 0010 3714 1112';
 
     protected function setUp(): void
     {
@@ -37,15 +35,6 @@ final class TpayPaymentCheckoutTest extends E2ETestCase
         $this->placeOrder();
 
         $this->assertPageTitleContains('Thank you!');
-    }
-
-    public function test_it_completes_the_checkout_using_credit_card(): void
-    {
-        $this->processWithPaymentMethod('tpay_card');
-        $this->fillCardData(self::FORM_ID, self::CARD_NUMBER, '123', '01', '2029');
-        $this->placeOrder();
-
-        $this->assertPageTitleContains('Waiting for payment | Web Channel');
     }
 
     public function test_it_completes_the_checkout_using_blik(): void

--- a/tests/E2E/Shop/Checkout/TpayVisaMobileCheckoutTest.php
+++ b/tests/E2E/Shop/Checkout/TpayVisaMobileCheckoutTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Checkout;
+namespace Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Shop\Checkout;
 
 use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\E2ETestCase;
 use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Helper\Account\LoginShopUserTrait;

--- a/tests/E2E/Shop/Order/TpayRetryOrChangePaymentOrderTest.php
+++ b/tests/E2E/Shop/Order/TpayRetryOrChangePaymentOrderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Order;
+namespace Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Shop\Order;
 
 use Facebook\WebDriver\WebDriverBy;
 use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\E2ETestCase;
@@ -93,7 +93,7 @@ final class TpayRetryOrChangePaymentOrderTest extends E2ETestCase
 
         $this->client->get('/en_US/order/tokenValue1');
         $form = $this->client->getCrawler()->selectButton('Pay')->form();
-        $form->getElement()->findElement(WebDriverBy::xpath("//label[contains(text(),'Bank (Tpay)')]"))->click();
+        $form->getElement()->findElement(WebDriverBy::xpath("//label[contains(text(),'Choose bank (Tpay)')]"))->click();
         $form->getElement()->findElement(WebDriverBy::cssSelector('.bank-tile[data-bank-id="1"]'))->click();
         $this->client->submitForm('Pay');
 

--- a/tests/E2E/Shop/RetryPayment/RetryingPaymentTest.php
+++ b/tests/E2E/Shop/RetryPayment/RetryingPaymentTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace E2E\RetryPayment;
+namespace Tests\CommerceWeavers\SyliusTpayPlugin\E2E\Shop\RetryPayment;
 
 use Tests\CommerceWeavers\SyliusTpayPlugin\Api\Utils\OrderPlacerTrait;
 use Tests\CommerceWeavers\SyliusTpayPlugin\E2E\E2ETestCase;

--- a/tests/Unit/PayByLinkPayment/ContextProvider/BankListContextProviderTest.php
+++ b/tests/Unit/PayByLinkPayment/ContextProvider/BankListContextProviderTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Tests\CommerceWeavers\SyliusTpayPlugin\Unit\PayByLinkPayment\ContextProvider;
 
 use CommerceWeavers\SyliusTpayPlugin\PayByLinkPayment\ContextProvider\BankListContextProvider;
+use CommerceWeavers\SyliusTpayPlugin\PayByLinkPayment\Payum\Factory\GatewayFactory as PayByLinkGatewayFactory;
 use CommerceWeavers\SyliusTpayPlugin\Tpay\Provider\ValidTpayChannelListProviderInterface;
+use Payum\Core\Security\CypherInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
-use Sylius\Bundle\PayumBundle\Model\GatewayConfigInterface;
+use Sylius\Bundle\PayumBundle\Model\GatewayConfig;
 use Sylius\Bundle\UiBundle\Registry\TemplateBlock;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
@@ -21,9 +23,12 @@ class BankListContextProviderTest extends TestCase
 
     private ValidTpayChannelListProviderInterface|ObjectProphecy $validTpayChannelListProvider;
 
+    private CypherInterface|ObjectProphecy $cypher;
+
     protected function setUp(): void
     {
         $this->validTpayChannelListProvider = $this->prophesize(ValidTpayChannelListProviderInterface::class);
+        $this->cypher = $this->prophesize(CypherInterface::class);
     }
 
     public function test_it_does_not_support_some_template_event_and_pay_by_link_template_name(): void
@@ -56,9 +61,10 @@ class BankListContextProviderTest extends TestCase
     public function test_it_provides_banks_in_template_context_if_method_is_present_in_context(): void
     {
         $paymentMethod = $this->prophesize(PaymentMethodInterface::class);
-        $gatewayConfig = $this->prophesize(GatewayConfigInterface::class);
+        $gatewayConfig = $this->prophesize(GatewayConfig::class);
         $paymentMethod->getGatewayConfig()->willReturn($gatewayConfig);
-        $gatewayConfig->getConfig()->willReturn(['type' => 'pay_by_link']);
+        $gatewayConfig->getFactoryName()->willReturn(PayByLinkGatewayFactory::NAME);
+        $gatewayConfig->getConfig()->willReturn([]);
         $this->validTpayChannelListProvider->provide()->willReturn(['3' => 'somebank']);
 
         $result = $this
@@ -69,6 +75,7 @@ class BankListContextProviderTest extends TestCase
             )
         ;
 
+        $gatewayConfig->decrypt($this->cypher)->shouldBeCalled();
         $this->assertSame(
             [
                 'method' => $paymentMethod->reveal(),
@@ -84,11 +91,12 @@ class BankListContextProviderTest extends TestCase
         $order = $this->prophesize(OrderInterface::class);
         $payment = $this->prophesize(PaymentInterface::class);
         $paymentMethod = $this->prophesize(PaymentMethodInterface::class);
-        $gatewayConfig = $this->prophesize(GatewayConfigInterface::class);
+        $gatewayConfig = $this->prophesize(GatewayConfig::class);
         $order->getLastPayment()->willReturn($payment);
         $payment->getMethod()->willReturn($paymentMethod);
         $paymentMethod->getGatewayConfig()->willReturn($gatewayConfig);
-        $gatewayConfig->getConfig()->willReturn(['type' => 'pay_by_link']);
+        $gatewayConfig->getFactoryName()->willReturn(PayByLinkGatewayFactory::NAME);
+        $gatewayConfig->getConfig()->willReturn([]);
         $this->validTpayChannelListProvider->provide()->willReturn(['3' => 'somebank']);
 
         $result = $this
@@ -99,6 +107,7 @@ class BankListContextProviderTest extends TestCase
             )
         ;
 
+        $gatewayConfig->decrypt($this->cypher)->shouldBeCalled();
         $this->assertSame(
             [
                 'order' => $order->reveal(),
@@ -179,9 +188,10 @@ class BankListContextProviderTest extends TestCase
     public function test_it_provides_channel_id_and_empty_banks_in_template_context_if_tpay_channel_id_is_specified(): void
     {
         $paymentMethod = $this->prophesize(PaymentMethodInterface::class);
-        $gatewayConfig = $this->prophesize(GatewayConfigInterface::class);
+        $gatewayConfig = $this->prophesize(GatewayConfig::class);
         $paymentMethod->getGatewayConfig()->willReturn($gatewayConfig);
-        $gatewayConfig->getConfig()->willReturn(['type' => 'pay_by_link', 'tpay_channel_id' => '3']);
+        $gatewayConfig->getFactoryName()->willReturn(PayByLinkGatewayFactory::NAME);
+        $gatewayConfig->getConfig()->willReturn(['tpay_channel_id' => '3']);
 
         $result = $this
             ->createTestObject()
@@ -191,6 +201,7 @@ class BankListContextProviderTest extends TestCase
             )
         ;
 
+        $gatewayConfig->decrypt($this->cypher)->shouldBeCalled();
         $this->validTpayChannelListProvider->provide()->shouldNotBeCalled();
         $this->assertSame(
             [
@@ -204,6 +215,9 @@ class BankListContextProviderTest extends TestCase
 
     private function createTestObject(): BankListContextProvider
     {
-        return new BankListContextProvider($this->validTpayChannelListProvider->reveal());
+        return new BankListContextProvider(
+            $this->validTpayChannelListProvider->reveal(),
+            $this->cypher->reveal(),
+        );
     }
 }

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -13,9 +13,11 @@ commerce_weavers_sylius_tpay:
             google_merchant_id: 'Google Merchant ID'
             apple_pay_merchant_id: 'Apple Merchant ID'
             tpay_channel_id: 'Tpay Channel ID'
+            tpay_channel_id_help: 'Click the "Test connection" button to retrieve the list of available channels.'
             production_mode: 'Production mode'
             merchant_id: 'Merchant ID'
             notification_security_code: 'Security code (Notification)'
+            test_connection: 'Test connection'
             type:
                 apple_pay: 'Apple Pay'
                 blik: 'BLIK'

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -12,6 +12,7 @@ commerce_weavers_sylius_tpay:
             client_secret: 'Secret'
             google_merchant_id: 'Google Merchant ID'
             apple_pay_merchant_id: 'Apple Merchant ID'
+            tpay_channel_id: 'Tpay Channel ID'
             production_mode: 'Production mode'
             merchant_id: 'Merchant ID'
             notification_security_code: 'Security code (Notification)'

--- a/translations/messages.pl.yaml
+++ b/translations/messages.pl.yaml
@@ -13,9 +13,11 @@ commerce_weavers_sylius_tpay:
             google_merchant_id: 'Identyfikator sprzedawcy Google'
             apple_pay_merchant_id: 'Identyfikator sprzedawcy Apple Pay'
             tpay_channel_id: 'ID kanału Tpay'
+            tpay_channel_id_help: 'Kliknij przycisk "Testuj połączenie", aby pobrać listę dostępnych kanałów.'
             production_mode: 'Tryb produkcyjny'
             merchant_id: 'Merchant ID'
             notification_security_code: 'Kod bezpieczeństwa (Powiadomienia)'
+            test_connection: 'Testuj połączenie'
             type:
                 apple_pay: 'Apple Pay'
                 blik: 'BLIK'

--- a/translations/messages.pl.yaml
+++ b/translations/messages.pl.yaml
@@ -12,6 +12,7 @@ commerce_weavers_sylius_tpay:
             client_secret: 'Secret'
             google_merchant_id: 'Identyfikator sprzedawcy Google'
             apple_pay_merchant_id: 'Identyfikator sprzedawcy Apple Pay'
+            tpay_channel_id: 'ID kanału Tpay'
             production_mode: 'Tryb produkcyjny'
             merchant_id: 'Merchant ID'
             notification_security_code: 'Kod bezpieczeństwa (Powiadomienia)'


### PR DESCRIPTION
If Tpay Channel ID defined, the Pay By Link payment type will automatically redirect to the specified channel without asking a customer to choose a channel manually.

TODO:
- [x] Refactor the JS code and move it to a .js file.
- [x] Fix missing translations.
- [x] Move the channel ID (e.g. for Twisto) to the dev env var and use it in the fixtures.
- [x] Tests.
- [x] UPGRADE file

Actions to take right after a releasing a new version:
- [ ] Update [wiki/1.-Installation](https://github.com/CommerceWeavers/SyliusTpayPlugin/wiki/1.-Installation) with customizations in `templates/bundles` and `index.js`.
- [ ] Update [wiki/2.-Configuring-a-new-payment-method-in-Admin-Panel](https://github.com/CommerceWeavers/SyliusTpayPlugin/wiki/2.-Configuring-a-new-payment-method-in-Admin-Panel) with an info about Channel ID that can be configured with PBL.