### PR TITLE
Fix not working payment notifications

### DIFF
--- a/src/Payum/Action/Api/NotifyAction.php
+++ b/src/Payum/Action/Api/NotifyAction.php
@@ -50,6 +50,11 @@ final class NotifyAction extends BasePaymentAwareAction implements GatewayAwareI
             throw new HttpResponse('FALSE - Invalid checksum', 400);
         }
 
+        /**
+         * @var string $status
+         *
+         * @phpstan-ignore varTag.type
+         */
         $status = $basicPayment->tr_status;
 
         $cardToken = $requestData->requestParameters['card_token'] ?? null;
@@ -64,10 +69,9 @@ final class NotifyAction extends BasePaymentAwareAction implements GatewayAwareI
             $this->gateway->execute(new SaveCreditCard($model, $cardToken, $cardBrand, $cardTail, $tokenExpirationDate));
         }
 
-        $statusValue = (string) $status->getValue();
         $newPaymentStatus = match (true) {
-            str_contains($statusValue, 'TRUE') => PaymentInterface::STATE_COMPLETED,
-            str_contains($statusValue, 'CHARGEBACK') => PaymentInterface::STATE_REFUNDED,
+            str_contains($status, 'TRUE') => PaymentInterface::STATE_COMPLETED,
+            str_contains($status, 'CHARGEBACK') => PaymentInterface::STATE_REFUNDED,
             default => PaymentInterface::STATE_FAILED,
         };
 


### PR DESCRIPTION
After some changes to satisfy the PHPStan the payment notification stopped working. This PR reverts these changes.