### PR TITLE
[DX-1300] - fix visa mobile error

### DIFF
--- a/src/Tpay/Factory/CreateVisaMobilePaymentPayloadFactory.php
+++ b/src/Tpay/Factory/CreateVisaMobilePaymentPayloadFactory.php
@@ -18,7 +18,10 @@ final class CreateVisaMobilePaymentPayloadFactory implements CreateVisaMobilePay
 
     public function createFrom(PaymentInterface $payment, string $notifyUrl, string $localeCode): array
     {
-        /** @var array{pay: array<string, mixed>} $payload */
+        /** @var array{
+         *     pay: array<string, mixed>,
+         *     payer: array{phone: ?string, ip: ?string, userAgent: ?string},
+         * } $payload */
         $payload = $this->createRedirectBasedPaymentPayloadFactory->createFrom($payment, $notifyUrl, $localeCode);
 
         $paymentDetails = PaymentDetails::fromArray($payment->getDetails());
@@ -30,6 +33,13 @@ final class CreateVisaMobilePaymentPayloadFactory implements CreateVisaMobilePay
 
         $payload['payer']['phone'] = $visaMobilePhoneNumber;
         $payload['pay']['groupId'] = PayGroup::VISA_MOBILE;
+
+        return $this->removeUnsupportedPayerDetails($payload);
+    }
+
+    private function removeUnsupportedPayerDetails(array $payload): array
+    {
+        unset($payload['payer']['ip'], $payload['payer']['userAgent']);
 
         return $payload;
     }


### PR DESCRIPTION
Error debugged from logs:
`Fields: {"result":"failed","requestId":"a40b7b2a1c463d3394d7","errors":[{"errorCode":"unexpected_field","errorMessage":"Field ip is unexpected for this request","fieldName":"ip","devMessage":"","docUrl":""},{"errorCode":"unexpected_field","errorMessage":"Field userAgent is unexpected for this request","fieldName":"userAgent","devMessage":"","docUrl":""}]} 
`

I am adding unsetting 'ip' and 'userAgent' field in the payload factory for it as other methods still support it.
Result after changes on completing checkout:
<img width="1196" height="695" alt="image" src="https://github.com/user-attachments/assets/ddfe3485-6bd6-4382-89d9-91bf09e170c7" />
