### PR TITLE
[DX-1298] - Fix broken card payment

### DIFF
--- a/src/CardPayment/Tpay/Factory/CreateCardPaymentPayloadFactory.php
+++ b/src/CardPayment/Tpay/Factory/CreateCardPaymentPayloadFactory.php
@@ -25,6 +25,13 @@ final class CreateCardPaymentPayloadFactory implements CreateCardPaymentPayloadF
 
         $payload['pay']['groupId'] = PayGroup::CARD;
 
+        return $this->removeUnsupportedPayerDetails($payload);
+    }
+
+    private function removeUnsupportedPayerDetails(array $payload): array
+    {
+        unset($payload['payer']['ip'], $payload['payer']['userAgent']);
+
         return $payload;
     }
 }


### PR DESCRIPTION
This PR should fix https://github.com/CommerceWeavers/SyliusTpayPlugin/issues/298

Error debugged from logs:
`Fields: {"result":"failed","requestId":"f99c12d0be54ff60080c","errors":[{"errorCode":"unexpected_field","errorMessage":"Field ip is unexpected for this request","fieldName":"ip","devMessage":"","docUrl":""},{"errorCode":"unexpected_field","errorMessage":"Field userAgent is unexpected for this request","fieldName":"userAgent","devMessage":"","docUrl":""}]}`

I am adding unsetting 'ip' and 'userAgent' field in the payload factory for it as other methods still support it.

After the changes I am redirected to the payment provider side (sandbox)
