### PR TITLE
Set FF client language preference in E2E tests

### DIFF
--- a/tests/E2E/E2ETestCase.php
+++ b/tests/E2E/E2ETestCase.php
@@ -7,6 +7,7 @@ namespace Tests\CommerceWeavers\SyliusTpayPlugin\E2E;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
+use Facebook\WebDriver\Firefox\FirefoxOptions;
 use Facebook\WebDriver\WebDriverDimension;
 use Fidry\AliceDataFixtures\LoaderInterface;
 use Symfony\Component\Panther\Client;
@@ -23,8 +24,11 @@ abstract class E2ETestCase extends PantherTestCase
 
     protected function setUp(): void
     {
+        $options = new FirefoxOptions();
+        $options->setPreference('intl.accept_languages', 'en-US');
+
         $this->client = static::createPantherClient([
-            'browser' => self::FIREFOX,
+            'browser' => self::FIREFOX, [], $options,
         ]);
         $this->client->manage()->window()->setSize(
             new WebDriverDimension(1500, 4000),


### PR DESCRIPTION
Enforce en-US language in Panther tests using Firefox to ensure consistent messages and views regardless of local environment settings.